### PR TITLE
🧹 Refactor duplicated Import Error boilerplate in LLM Providers

### DIFF
--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/llm_provider.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/llm_provider.py
@@ -1,8 +1,30 @@
+import functools
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 from pdf_anonymizer_core.conf import DEFAULT_CHARACTERS_TO_ANONYMIZE
+
+
+def validate_import(extra_name: str):
+    """
+    Decorator to handle ImportError for optional dependencies.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except ImportError:
+                raise ImportError(
+                    f"The '{extra_name}' extra is not installed. "
+                    f"Please run 'pip install \"pdf-anonymizer-core[{extra_name}]\"'."
+                )
+
+        return wrapper
+
+    return decorator
 
 
 class LLMProvider(ABC):
@@ -19,16 +41,11 @@ class LLMProvider(ABC):
 
 
 class GoogleProvider(LLMProvider):
+    @validate_import("google")
     def __init__(self):
-        try:
-            from google import genai
+        from google import genai
 
-            self.genai = genai
-        except ImportError:
-            raise ImportError(
-                "The 'google' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[google]\"'."
-            )
+        self.genai = genai
         if not os.getenv("GOOGLE_API_KEY"):
             raise ValueError("GOOGLE_API_KEY environment variable not set.")
 
@@ -41,16 +58,11 @@ class GoogleProvider(LLMProvider):
 
 
 class OllamaProvider(LLMProvider):
+    @validate_import("ollama")
     def __init__(self):
-        try:
-            import ollama
+        import ollama
 
-            self.ollama = ollama
-        except ImportError:
-            raise ImportError(
-                "The 'ollama' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[ollama]\"'."
-            )
+        self.ollama = ollama
 
     def call(
         self, prompt: str, model_name: str, max_output_tokens: Optional[int] = None
@@ -69,16 +81,11 @@ class OllamaProvider(LLMProvider):
 
 
 class HuggingFaceProvider(LLMProvider):
+    @validate_import("huggingface")
     def __init__(self):
-        try:
-            from huggingface_hub import InferenceClient
+        from huggingface_hub import InferenceClient
 
-            self.InferenceClient = InferenceClient
-        except ImportError:
-            raise ImportError(
-                "The 'huggingface' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[huggingface]\"'."
-            )
+        self.InferenceClient = InferenceClient
         if not os.getenv("HUGGING_FACE_TOKEN"):
             raise ValueError("HUGGING_FACE_TOKEN environment variable not set.")
 
@@ -103,16 +110,11 @@ class HuggingFaceProvider(LLMProvider):
 
 
 class OpenRouterProvider(LLMProvider):
+    @validate_import("openrouter")
     def __init__(self):
-        try:
-            from openai import OpenAI
+        from openai import OpenAI
 
-            self.OpenAI = OpenAI
-        except ImportError:
-            raise ImportError(
-                "The 'openrouter' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[openrouter]\"'."
-            )
+        self.OpenAI = OpenAI
         if not os.getenv("OPENROUTER_API_KEY"):
             raise ValueError("OPENROUTER_API_KEY environment variable not set.")
 
@@ -130,16 +132,11 @@ class OpenRouterProvider(LLMProvider):
 
 
 class OpenAIProvider(LLMProvider):
+    @validate_import("openai")
     def __init__(self):
-        try:
-            from openai import OpenAI
+        from openai import OpenAI
 
-            self.OpenAI = OpenAI
-        except ImportError:
-            raise ImportError(
-                "The 'openai' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[openai]\"'."
-            )
+        self.OpenAI = OpenAI
         if not os.getenv("OPENAI_API_KEY"):
             raise ValueError("OPENAI_API_KEY environment variable not set.")
 
@@ -154,16 +151,11 @@ class OpenAIProvider(LLMProvider):
 
 
 class AnthropicProvider(LLMProvider):
+    @validate_import("anthropic")
     def __init__(self):
-        try:
-            from anthropic import Anthropic
+        from anthropic import Anthropic
 
-            self.Anthropic = Anthropic
-        except ImportError:
-            raise ImportError(
-                "The 'anthropic' extra is not installed. "
-                "Please run 'pip install \"pdf-anonymizer-core[anthropic]\"'."
-            )
+        self.Anthropic = Anthropic
         if not os.getenv("ANTHROPIC_API_KEY"):
             raise ValueError("ANTHROPIC_API_KEY environment variable not set.")
 

--- a/tests/test_llm_provider_imports.py
+++ b/tests/test_llm_provider_imports.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+import sys
+from pdf_anonymizer_core.llm_provider import (
+    GoogleProvider,
+    OllamaProvider,
+    HuggingFaceProvider,
+    OpenRouterProvider,
+    OpenAIProvider,
+    AnthropicProvider,
+)
+
+class TestLLMProviderImports(unittest.TestCase):
+    def test_google_provider_import_error(self):
+        with patch.dict(sys.modules, {'google': None}):
+            with self.assertRaisesRegex(ImportError, "The 'google' extra is not installed"):
+                GoogleProvider()
+
+    def test_ollama_provider_import_error(self):
+        with patch.dict(sys.modules, {'ollama': None}):
+            with self.assertRaisesRegex(ImportError, "The 'ollama' extra is not installed"):
+                OllamaProvider()
+
+    def test_huggingface_provider_import_error(self):
+        with patch.dict(sys.modules, {'huggingface_hub': None}):
+            with self.assertRaisesRegex(ImportError, "The 'huggingface' extra is not installed"):
+                HuggingFaceProvider()
+
+    def test_openrouter_provider_import_error(self):
+        # OpenRouter uses 'openai'
+        with patch.dict(sys.modules, {'openai': None}):
+            with self.assertRaisesRegex(ImportError, "The 'openrouter' extra is not installed"):
+                OpenRouterProvider()
+
+    def test_openai_provider_import_error(self):
+        with patch.dict(sys.modules, {'openai': None}):
+            with self.assertRaisesRegex(ImportError, "The 'openai' extra is not installed"):
+                OpenAIProvider()
+
+    def test_anthropic_provider_import_error(self):
+        with patch.dict(sys.modules, {'anthropic': None}):
+            with self.assertRaisesRegex(ImportError, "The 'anthropic' extra is not installed"):
+                AnthropicProvider()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR improves the maintainability and readability of the LLM provider implementations by standardizing how optional dependency imports are handled.

🎯 **What:** 
- Introduced a `validate_import(extra_name)` decorator in `pdf_anonymizer_core.llm_provider`.
- Replaced repetitive `try...except ImportError` blocks in `GoogleProvider`, `OllamaProvider`, `HuggingFaceProvider`, `OpenRouterProvider`, `OpenAIProvider`, and `AnthropicProvider` with the new decorator.
- Added comprehensive tests for these error conditions.

💡 **Why:** 
The previous implementation had a lot of boilerplate code for each provider to check if its required package was installed. This refactoring centralizes that logic, making it easier to add new providers and ensuring a consistent user experience when an optional extra is missing.

✅ **Verification:** 
- New tests in `tests/test_llm_provider_imports.py` verify that the correct `ImportError` with the expected message is raised for each provider when its module is unavailable. These tests mock `sys.modules` to be environment-independent.
- Existing tests in `tests/test_main.py` (using mocks for the LLM calls) continue to pass.

✨ **Result:** 
Cleaner, more maintainable code with a standardized pattern for handling optional dependencies across all LLM providers.

---
*PR created automatically by Jules for task [11010072440898765876](https://jules.google.com/task/11010072440898765876) started by @leo-gan*