### PR TITLE
feat: filter national-ID regexes by country

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -8,7 +8,7 @@
 
 - [x] 1. Prompt: implied / contextual PII — done 2026-08-14, [PR #40](https://github.com/leo-gan/anonymizer/pull/40)
 - [x] 2. Checksum validators on structured regex hits — done 2026-08-14, [PR #41](https://github.com/leo-gan/anonymizer/pull/41)
-- [ ] 3. Country filter for regex patterns
+- [x] 3. Country filter for regex patterns — done 2026-08-14, `feat/regex-country-filter`
 - [ ] 4. Residual-PII verification pass
 - [ ] 5. Encrypted mapping file
 - [ ] 6. Generalization and per-entity operators
@@ -46,6 +46,7 @@ Known code facts to attach to:
 - `core.py`: replacement is whole-document string match, not character spans.
 - `prompts/detailed.py`: asks for identity clues (`INDIRECT`, or `PERSON` with a known `base_form`) plus birthdates; `simple.py` does not. Shipped in [PR #40](https://github.com/leo-gan/anonymizer/pull/40).
 - Recipes already call the mapping file “the key”; it is not encrypted.
+- National-ID regexes can be limited with `filter_regex_patterns(["US", "GB"])` or CLI `--countries US,GB`. Universal patterns always stay.
 
 ---
 
@@ -99,6 +100,8 @@ Known code facts to attach to:
 ---
 
 ### 3. Country filter for regex patterns
+
+**Status:** done (2026-08-14) — `feat/regex-country-filter` (PR link after open)
 
 **Technique:** data removal, less noise. Already designed in `conf.py` comments, not exposed.
 

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -8,7 +8,7 @@
 
 - [x] 1. Prompt: implied / contextual PII — done 2026-08-14, [PR #40](https://github.com/leo-gan/anonymizer/pull/40)
 - [x] 2. Checksum validators on structured regex hits — done 2026-08-14, [PR #41](https://github.com/leo-gan/anonymizer/pull/41)
-- [x] 3. Country filter for regex patterns — done 2026-08-14, `feat/regex-country-filter`
+- [x] 3. Country filter for regex patterns — done 2026-08-14, [PR #42](https://github.com/leo-gan/anonymizer/pull/42)
 - [ ] 4. Residual-PII verification pass
 - [ ] 5. Encrypted mapping file
 - [ ] 6. Generalization and per-entity operators
@@ -101,7 +101,7 @@ Known code facts to attach to:
 
 ### 3. Country filter for regex patterns
 
-**Status:** done (2026-08-14) — `feat/regex-country-filter` (PR link after open)
+**Status:** done (2026-08-14) — [PR #42](https://github.com/leo-gan/anonymizer/pull/42) (`feat/regex-country-filter`)
 
 **Technique:** data removal, less noise. Already designed in `conf.py` comments, not exposed.
 

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -25,6 +25,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--prompt-name` | `simple` \| `detailed` | `detailed` | Instruction style sent to the language model (overrides profile). `detailed` also hides identity clues. `simple` does not. |
 | `--model-name` | `TEXT` | `gemini-2.5-flash` | The identifier of the model to execute (overrides profile). |
 | `--anonymized-entities` | `PATH` | *None* | Path to a text file containing custom entities to search for and anonymize. |
+| `--countries` | `TEXT` | *all* | ISO-2 codes for national-ID regexes, comma-separated (`US,GB`). Email, IBAN, cards, and other universal patterns always stay. |
 
 ### Configuration Profiles
 
@@ -44,6 +45,9 @@ pdf-anonymizer run contract.pdf -p best-quality
 
 # Fast + cheap batch of notes with a local model
 pdf-anonymizer run notes/*.md -p best-cost --model-name "ollama/phi4-mini"
+
+# Only US and UK national-ID patterns (email, IBAN, cards still run)
+pdf-anonymizer run contract.pdf --countries US,GB
 ```
 
 See the [Recipes & Common Workflows](recipes.md) page for more profile usage patterns.

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -330,6 +330,36 @@ PDF Anonymizer is designed for files up to ~1 GB thanks to streaming chunking.
 
 ---
 
+## Limit national-ID regexes to some countries
+
+The first, fast search knows ID shapes for 30+ countries. On a US contract that is extra noise: a Polish PESEL or an Indian Aadhaar pattern can fire on a random digit string.
+
+`--countries` keeps **every universal pattern** (email, phone, URL, card, IBAN, IP, MAC, crypto, VIN, dates, amounts) and only the national IDs for the codes you list.
+
+```bash
+pdf-anonymizer run contract.pdf --countries US,GB
+```
+
+That still finds emails and IBANs. It still finds a US SSN and a UK National Insurance number. It does **not** run the Polish, Indian, or Chinese national-ID patterns.
+
+Use ISO-2 codes (`US`, `GB`, `FR`, …), comma-separated, any case. Unknown codes stop the run with an error.
+
+**SDK**
+
+```python
+from pdf_anonymizer_core.conf import filter_regex_patterns, get_config_for_profile, ConfigProfile
+
+# Same filter the CLI uses
+only_us_gb = filter_regex_patterns(["US", "GB"])
+
+cfg = get_config_for_profile(ConfigProfile.BEST_SPEED, countries=["US", "GB"])
+# cfg.regex_patterns is already filtered
+```
+
+This is a regex-stage setting only. The language model still reads the whole page and can name an ID from another country if the text is clear.
+
+---
+
 ## Advanced: Custom First-Stage Regex (SDK only)
 
 The hybrid approach runs a fast deterministic RE2 (google-re2) regex pass before every LLM call.
@@ -337,7 +367,7 @@ You can supply your own set (or a filtered slice of the built-in collection):
 
 ```python
 from pdf_anonymizer_core.core import anonymize_file
-from pdf_anonymizer_core.conf import get_config_for_profile, ConfigProfile, DEFAULT_REGEX_PATTERNS
+from pdf_anonymizer_core.conf import get_config_for_profile, ConfigProfile
 from pdf_anonymizer_core.prompts import detailed
 
 # Option A: completely custom
@@ -347,16 +377,10 @@ custom_regex = {
     # ...
 }
 
-# Option B: use the built-in library (RE2-powered, 30+ countries)
-# It includes: EMAIL, URL, CREDIT_CARD, IBAN, CRYPTO_*, VIN, MAC, IPV4/6,
-# DATE_ISO, CURRENCY_AMOUNT, BIC_SWIFT + country partitioned IDs:
-# SSN_US / SIN_CA / NINO_GB / INSEE_FR / DNI_ES / CODICE_FISCALE_IT / AADHAAR_IN / RESIDENT_ID_CN / ...
-# VAT_*/EIN_*/business numbers, DRIVERS_LICENSE_*, PASSPORT_*, MEDICAL_* etc.
-country_focused = {
-    k: v for k, v in DEFAULT_REGEX_PATTERNS.items()
-    if k in ("EMAIL", "CREDIT_CARD", "IBAN", "SSN_US", "SIN_CA", "NINO_GB", "INSEE_FR",
-             "RESIDENT_ID_CN", "PAN_IN", "VAT_FR", "VAT_DE", "DRIVERS_LICENSE_US")
-}
+# Option B: built-in library, limited to some countries (plus all universal keys)
+from pdf_anonymizer_core.conf import filter_regex_patterns
+
+country_focused = filter_regex_patterns(["US", "CA", "GB", "FR", "IN", "CN", "DE"])
 
 cfg = get_config_for_profile(ConfigProfile.BEST_SPEED)
 

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -61,7 +61,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
   [--characters-to-anonymize INTEGER] \
   [--prompt-name {simple|detailed}] \
   [--model-name TEXT] \
-  [--anonymized-entities PATH]
+  [--anonymized-entities PATH] \
+  [--countries US,GB]
 ```
 
 **Arguments**:
@@ -73,6 +74,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `--prompt-name [simple|detailed]`: The prompt template to use (default: `detailed`; overrides profile).
 - `--model-name TEXT`: The language model to use (overrides profile).
 - `--anonymized-entities PATH`: Path to a file with a list of entities to anonymize.
+- `--countries TEXT`: ISO-2 country codes for national-ID regexes, comma-separated (e.g. `US,GB`). Universal patterns (email, IBAN, cards, …) always stay. Default: all countries.
 
 **Models**:
 You can use any of the predefined models below, or specify a new model using the format `"provider/model-name"`. 

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -95,19 +95,39 @@ def run(
             resolve_path=True,
         ),
     ] = None,
+    countries: Annotated[
+        Optional[str],
+        typer.Option(
+            "--countries",
+            help=(
+                "ISO-2 country codes for national-ID regexes, comma-separated "
+                "(e.g. US,GB). Universal patterns such as email and IBAN always "
+                "stay. Default: all countries."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Anonymize one or more files by replacing PII with anonymized placeholders.
     """
     load_environment()
 
+    country_list = None
+    if countries:
+        country_list = [part.strip() for part in countries.split(",") if part.strip()]
+
     # Get configuration based on profile and optional user overrides
-    config = get_config_for_profile(
-        profile=config_profile,
-        model_name=model_name,
-        prompt_name=prompt_name,
-        chunk_size=characters_to_anonymize,
-    )
+    try:
+        config = get_config_for_profile(
+            profile=config_profile,
+            model_name=model_name,
+            prompt_name=prompt_name,
+            chunk_size=characters_to_anonymize,
+            countries=country_list,
+        )
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
 
     # Configure LLM caching with values from configuration
     configure_cache(
@@ -129,6 +149,9 @@ def run(
     logging.info(f"  --chunk-size: {config.chunk_size}")
     logging.info(f"  --chunk-overlap: {config.chunk_overlap}")
     logging.info(f"  --model-name: {config.model_name}")
+    if country_list:
+        logging.info(f"  --countries: {country_list}")
+        logging.info(f"  --regex-patterns: {len(config.regex_patterns)} after country filter")
 
     # Select the appropriate prompt template
     prompt_templates: Dict[str, str] = {

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -115,6 +115,15 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+To keep only some countries' national-ID regexes (plus every universal pattern):
+
+```python
+from pdf_anonymizer_core.conf import filter_regex_patterns, get_config_for_profile, ConfigProfile
+
+only_us_gb = filter_regex_patterns(["US", "GB"])
+cfg = get_config_for_profile(ConfigProfile.BEST_SPEED, countries=["US", "GB"])
+```
+
 ---
 
 ## See Also

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
@@ -11,7 +11,7 @@ This module defines:
 """
 
 from enum import Enum
-from typing import Any, Dict, Optional, Type, TypeVar
+from typing import Any, Dict, Iterable, Optional, Type, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -44,9 +44,8 @@ DEFAULT_LOG_FILE: str = "app.log"
 #   hidden. The LLM stage still follows for context-dependent or missed PII.
 # - Entity type keys use UPPER_SNAKE_CASE. Country-specific patterns are partitioned
 #   using ISO 3166-1 alpha-2 suffixes (e.g. SSN_US, NINO_GB, INSEE_FR, AADHAAR_IN,
-#   RESIDENT_ID_CN). This makes it trivial for callers to select a country subset:
-#       {k: v for k, v in DEFAULT_REGEX_PATTERNS.items()
-#        if not k.endswith(("_US", "_CA", ...)) or k.endswith("_US")}
+#   RESIDENT_ID_CN). Call filter_regex_patterns(countries=["US", "GB"]) to keep
+#   those national IDs plus every universal key (EMAIL, IBAN, CREDIT_CARD, ...).
 # - Universal patterns (EMAIL, CREDIT_CARD, IBAN, VIN, IPV4_ADDRESS, etc.) apply
 #   globally and are always included.
 # - All patterns are RE2-compatible (no look-around assertions, no Python-specific
@@ -219,6 +218,104 @@ DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
     "SSN": r"\b\d{3}-\d{2}-\d{4}\b",  # maps to US SSN
 }
 
+# ISO-2 suffixes used on country-specific keys (SSN_US, NINO_GB, PESEL_PL, ...).
+COUNTRY_PATTERN_SUFFIXES: frozenset[str] = frozenset(
+    {
+        "US",
+        "CA",
+        "GB",
+        "FR",
+        "ES",
+        "IT",
+        "IN",
+        "CN",
+        "DE",
+        "JP",
+        "KR",
+        "AU",
+        "NZ",
+        "BR",
+        "MX",
+        "AR",
+        "ZA",
+        "SG",
+        "HK",
+        "TW",
+        "NL",
+        "BE",
+        "CH",
+        "AT",
+        "SE",
+        "NO",
+        "DK",
+        "FI",
+        "PL",
+        "IE",
+        "PT",
+        "GR",
+        "IL",
+        "TR",
+        "RU",
+        "TH",
+        "MY",
+        "ID",
+    }
+)
+
+# Keys with no suffix that still belong to one country.
+_PATTERN_COUNTRY_ALIASES: Dict[str, str] = {
+    "SSN": "US",
+}
+
+
+def pattern_country(key: str) -> Optional[str]:
+    """Return the ISO-2 country for a pattern key, or None if it is universal."""
+    upper = key.upper()
+    if upper in _PATTERN_COUNTRY_ALIASES:
+        return _PATTERN_COUNTRY_ALIASES[upper]
+    suffix = upper.rsplit("_", 1)[-1]
+    if suffix in COUNTRY_PATTERN_SUFFIXES:
+        return suffix
+    return None
+
+
+def filter_regex_patterns(
+    countries: Optional[Iterable[str]] = None,
+    patterns: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Keep universal patterns plus national-ID patterns for ``countries``.
+
+    Universal keys (EMAIL, IBAN, CREDIT_CARD, VIN, ...) always stay.
+    Country keys (SSN_US, NINO_GB, PESEL_PL, legacy SSN, ...) stay only when
+    their ISO-2 code is in ``countries``.
+
+    ``countries`` is a list of ISO-2 codes such as ``["US", "GB"]``.
+    ``None`` or an empty list returns a copy of all ``patterns``.
+    Unknown codes raise ``ValueError``.
+    """
+    source = DEFAULT_REGEX_PATTERNS if patterns is None else patterns
+    if not countries:
+        return dict(source)
+
+    wanted = {code.strip().upper() for code in countries if code and str(code).strip()}
+    if not wanted:
+        return dict(source)
+
+    unknown = sorted(wanted - COUNTRY_PATTERN_SUFFIXES)
+    if unknown:
+        raise ValueError(
+            "Unknown country code(s): "
+            + ", ".join(unknown)
+            + ". Use ISO-2 codes such as US, GB, FR."
+        )
+
+    filtered: Dict[str, str] = {}
+    for key, pattern in source.items():
+        country = pattern_country(key)
+        if country is None or country in wanted:
+            filtered[key] = pattern
+    return filtered
+
 
 # Config Profiles
 class ConfigProfile(str, Enum):
@@ -286,6 +383,7 @@ def get_config_for_profile(
     prompt_name: Optional[str] = None,
     chunk_size: Optional[int] = None,
     chunk_overlap: Optional[int] = None,
+    countries: Optional[Iterable[str]] = None,
 ) -> AppConfig:
     """Return an AppConfig populated from one of the built-in profiles.
 
@@ -302,6 +400,8 @@ def get_config_for_profile(
         prompt_name: Optional override ("simple" or "detailed").
         chunk_size: Optional override for characters_to_anonymize / chunk_size.
         chunk_overlap: Optional override for chunk overlap.
+        countries: Optional ISO-2 codes that limit national-ID regexes
+            (universal patterns always stay).
 
     Returns:
         A fully populated AppConfig instance ready to drive anonymize_file
@@ -325,6 +425,7 @@ def get_config_for_profile(
         max_retries=profile_defaults["max_retries"],
         base_retry_delay=profile_defaults["base_retry_delay"],
         max_retry_delay=profile_defaults["max_retry_delay"],
+        regex_patterns=filter_regex_patterns(countries),
     )
 
 

--- a/tests/test_country_filter.py
+++ b/tests/test_country_filter.py
@@ -1,0 +1,95 @@
+"""Country filter for first-stage regex patterns."""
+
+import pytest
+
+from pdf_anonymizer_core.conf import (
+    COUNTRY_PATTERN_SUFFIXES,
+    DEFAULT_REGEX_PATTERNS,
+    ConfigProfile,
+    filter_regex_patterns,
+    get_config_for_profile,
+    pattern_country,
+)
+
+
+class TestPatternCountry:
+    def test_universal_keys_have_no_country(self) -> None:
+        for key in (
+            "EMAIL",
+            "PHONE",
+            "URL",
+            "CREDIT_CARD",
+            "IBAN",
+            "IPV4_ADDRESS",
+            "IPV6_ADDRESS",
+            "MAC_ADDRESS",
+            "CRYPTO_BTC",
+            "CRYPTO_ETH",
+            "DATE_ISO",
+            "VIN",
+            "BIC_SWIFT",
+            "CURRENCY_AMOUNT",
+            "IP_ADDRESS",
+        ):
+            assert pattern_country(key) is None, key
+
+    def test_suffixed_and_alias_keys(self) -> None:
+        assert pattern_country("SSN_US") == "US"
+        assert pattern_country("NINO_GB") == "GB"
+        assert pattern_country("PESEL_PL") == "PL"
+        assert pattern_country("AADHAAR_IN") == "IN"
+        assert pattern_country("SSN") == "US"
+
+
+class TestFilterRegexPatterns:
+    def test_none_or_empty_returns_all(self) -> None:
+        assert filter_regex_patterns(None) == DEFAULT_REGEX_PATTERNS
+        assert filter_regex_patterns([]) == DEFAULT_REGEX_PATTERNS
+
+    def test_keeps_universals_and_selected_countries(self) -> None:
+        filtered = filter_regex_patterns(["US", "GB"])
+        assert "EMAIL" in filtered
+        assert "IBAN" in filtered
+        assert "CREDIT_CARD" in filtered
+        assert "SSN_US" in filtered
+        assert "SSN" in filtered
+        assert "NINO_GB" in filtered
+        assert "VAT_GB" in filtered
+        assert "PESEL_PL" not in filtered
+        assert "AADHAAR_IN" not in filtered
+        assert "INSEE_FR" not in filtered
+
+    def test_gb_only_drops_us_alias(self) -> None:
+        filtered = filter_regex_patterns(["gb"])
+        assert "NINO_GB" in filtered
+        assert "EMAIL" in filtered
+        assert "SSN" not in filtered
+        assert "SSN_US" not in filtered
+
+    def test_unknown_code_raises(self) -> None:
+        with pytest.raises(ValueError, match="XX"):
+            filter_regex_patterns(["US", "XX"])
+
+    def test_custom_pattern_dict_is_filtered(self) -> None:
+        custom = {
+            "EMAIL": "e",
+            "SSN_US": "u",
+            "NINO_GB": "g",
+        }
+        filtered = filter_regex_patterns(["US"], patterns=custom)
+        assert filtered == {"EMAIL": "e", "SSN_US": "u"}
+
+    def test_profile_helper_applies_filter(self) -> None:
+        cfg = get_config_for_profile(ConfigProfile.BEST_SPEED, countries=["FR"])
+        assert "INSEE_FR" in cfg.regex_patterns
+        assert "EMAIL" in cfg.regex_patterns
+        assert "NINO_GB" not in cfg.regex_patterns
+
+    def test_suffix_set_covers_builtin_country_keys(self) -> None:
+        seen = {
+            pattern_country(key)
+            for key in DEFAULT_REGEX_PATTERNS
+            if pattern_country(key)
+        }
+        assert seen <= COUNTRY_PATTERN_SUFFIXES
+        assert len(seen) >= 20


### PR DESCRIPTION
## Summary

The first, fast search knows ID shapes for 30+ countries. On a US contract that is extra noise: a Polish PESEL or an Indian Aadhaar pattern can fire on a random digit string.

`--countries US,GB` keeps **every universal pattern** (email, phone, URL, card, IBAN, IP, MAC, crypto, VIN, dates, amounts) and only the national IDs for the codes you list.

Default is unchanged: all countries. Unknown codes stop the run.

## How to try it

```bash
pdf-anonymizer run contract.pdf --countries US,GB
```

```python
from pdf_anonymizer_core.conf import filter_regex_patterns, get_config_for_profile, ConfigProfile

filter_regex_patterns(["US", "GB"])
get_config_for_profile(ConfigProfile.BEST_SPEED, countries=["US", "GB"])
```

The language model still reads the whole page and can name an ID from another country if the text is clear.

## Docs

Recipes: “Limit national-ID regexes to some countries.” Also CLI usage and both package READMEs. No 101 page.

This is plan item 3 from `docs/internal/improvement-plan.md` (not published on GitHub Pages).

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (77 tests).