### PR TITLE
feat: scan anonymized text for leftover personal details

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -9,7 +9,7 @@
 - [x] 1. Prompt: implied / contextual PII — done 2026-08-14, [PR #40](https://github.com/leo-gan/anonymizer/pull/40)
 - [x] 2. Checksum validators on structured regex hits — done 2026-08-14, [PR #41](https://github.com/leo-gan/anonymizer/pull/41)
 - [x] 3. Country filter for regex patterns — done 2026-08-14, [PR #42](https://github.com/leo-gan/anonymizer/pull/42)
-- [ ] 4. Residual-PII verification pass
+- [x] 4. Residual-PII verification pass — done 2026-08-14, `feat/residual-pii-verify`
 - [ ] 5. Encrypted mapping file
 - [ ] 6. Generalization and per-entity operators
 - [ ] 7. Quasi-identifier / linkage risk report
@@ -38,7 +38,7 @@ This product is a **reversible document pseudonymizer**: typed placeholders (`PE
 | *k*-anonymity / ℓ-diversity / *t*-closeness | Not implemented (tabular models; do not rewrite PDFs with them) |
 | Synthetic data | Not implemented |
 | Cryptographic methods | Mapping stored as plaintext |
-| Re-ID / attack simulation | Deanonymize stats only (`unused` / `not_found`) |
+| Re-ID / attack simulation | Residual regex scan after `run` / `verify` (`data/stats/<stem>.residual_pii.json`); deanonymize stats still `unused` / `not_found` |
 
 Known code facts to attach to:
 
@@ -119,19 +119,21 @@ Known code facts to attach to:
 
 ### 4. Residual-PII verification pass
 
+**Status:** done (2026-08-14) — `feat/residual-pii-verify` (PR link after open)
+
 **Technique:** the “Attack Simulation” box in history.md; Ohm / Netflix / AOL.  
 **Why:** there is no check that the *output* is clean. Chunked LLM + regex can both miss.
 
 **Do**
 
-- After replacement, re-run regex NER on the anonymized text (cheap, always).
-- Optionally a short LLM “find remaining PII” prompt behind a flag.
+- After replacement, re-run regex NER on the anonymized text (cheap, default on).
+- Optionally a short LLM “find remaining PII” prompt behind `--verify-llm`.
 - Write `data/stats/<stem>.residual_pii.json`.
-- CLI: `--verify` and/or `pdf-anonymizer verify`.
-- **Report first. Do not auto-rewrite** unless a later explicit flag is added.
+- CLI: `--verify` / `--no-verify` and `pdf-anonymizer verify`.
+- **Report first. Do not auto-rewrite.**
 
-**Touches:** new `verify.py`, CLI subcommand or flag, stats schema. Do not change the `anonymize_file` return contract unless necessary.  
-**Prerequisite:** none. Becomes more useful after (1) and (2).
+**Touches:** `verify.py`, CLI, recipes / README. `anonymize_file` return contract unchanged.  
+**Prerequisite:** none.
 
 ---
 

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -9,7 +9,7 @@
 - [x] 1. Prompt: implied / contextual PII — done 2026-08-14, [PR #40](https://github.com/leo-gan/anonymizer/pull/40)
 - [x] 2. Checksum validators on structured regex hits — done 2026-08-14, [PR #41](https://github.com/leo-gan/anonymizer/pull/41)
 - [x] 3. Country filter for regex patterns — done 2026-08-14, [PR #42](https://github.com/leo-gan/anonymizer/pull/42)
-- [x] 4. Residual-PII verification pass — done 2026-08-14, `feat/residual-pii-verify`
+- [x] 4. Residual-PII verification pass — done 2026-08-14, [PR #43](https://github.com/leo-gan/anonymizer/pull/43)
 - [ ] 5. Encrypted mapping file
 - [ ] 6. Generalization and per-entity operators
 - [ ] 7. Quasi-identifier / linkage risk report
@@ -119,7 +119,7 @@ Known code facts to attach to:
 
 ### 4. Residual-PII verification pass
 
-**Status:** done (2026-08-14) — `feat/residual-pii-verify` (PR link after open)
+**Status:** done (2026-08-14) — [PR #43](https://github.com/leo-gan/anonymizer/pull/43) (`feat/residual-pii-verify`)
 
 **Technique:** the “Attack Simulation” box in history.md; Ohm / Netflix / AOL.  
 **Why:** there is no check that the *output* is clean. Chunked LLM + regex can both miss.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -58,6 +58,11 @@ graph TD
     *   **Text/Fallback**: Uses `langchain_text_splitters.RecursiveCharacterTextSplitter`.
 *   This keeps individual requests within LLM token constraints and limits memory footprints.
 
+### Residual check (after replacement)
+*   The CLI re-runs the cheap regex pass on the masked text (unless `--no-verify`).
+*   Stand-in labels (`PERSON_1`, `IBAN_LIKE_1`) are ignored. Leftover emails or numbers are written to `data/stats/<stem>.residual_pii.json`.
+*   The file is not rewritten. `--verify-llm` adds an optional second read by the language model. `pdf-anonymizer verify` runs the same scan later.
+
 ### Regex first pass (with checksums)
 *   Each chunk is scanned with the RE2 pattern library (emails, cards, IBANs, national IDs, and so on).
 *   A hit that has a cheap extra digit check (card Luhn, IBAN mod-97, VIN check digit, a few national IDs) is relabeled ``TYPE_LIKE`` if that check fails (for example ``IBAN_LIKE``). The text is still replaced. A verified hit keeps the real type and wins if both labels appear for the same span. Listing ``IBAN`` in ``--anonymized-entities`` also includes ``IBAN_LIKE``.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -26,6 +26,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--model-name` | `TEXT` | `gemini-2.5-flash` | The identifier of the model to execute (overrides profile). |
 | `--anonymized-entities` | `PATH` | *None* | Path to a text file containing custom entities to search for and anonymize. |
 | `--countries` | `TEXT` | *all* | ISO-2 codes for national-ID regexes, comma-separated (`US,GB`). Email, IBAN, cards, and other universal patterns always stay. |
+| `--verify` / `--no-verify` | flag | on | After masking, scan the result for leftovers (cheap regex). Writes `data/stats/<stem>.residual_pii.json`. Does not change the file. |
+| `--verify-llm` | flag | off | Also ask the language model to hunt for leftovers. |
 
 ### Configuration Profiles
 
@@ -91,6 +93,21 @@ To use any model not listed in the aliases, pass the string as `provider/model-n
 ```bash
 pdf-anonymizer run doc.pdf --model-name "google/gemini-2.0-flash-exp"
 ```
+
+---
+
+## The `verify` Command (leftover check)
+
+Scan an already-masked file. This only writes a report. It does not change the file.
+
+```bash
+pdf-anonymizer verify data/anonymized/notes.anonymized.md
+pdf-anonymizer verify data/anonymized/notes.anonymized.md --verify-llm -p best-quality
+```
+
+The report is `data/stats/<stem>.residual_pii.json`. Stand-in labels such as `PERSON_1` are ignored. A leftover email or a mistyped IBAN is listed.
+
+`run` already does the cheap regex scan unless you pass `--no-verify`.
 
 ---
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -330,6 +330,34 @@ PDF Anonymizer is designed for files up to ~1 GB thanks to streaming chunking.
 
 ---
 
+## Check the masked file for leftovers
+
+Hiding names is a first pass. A leftover email or a mistyped IBAN can still sit in the masked page.
+
+After `run`, the tool scans the result with the same cheap number/email search. It **does not rewrite** the file. It writes a report:
+
+`data/stats/<stem>.residual_pii.json`
+
+Stand-in labels such as `PERSON_1` or `IBAN_LIKE_1` are ignored. Real leftovers are listed.
+
+```bash
+# Default: regex scan after every run
+pdf-anonymizer run notes.pdf
+
+# Skip the scan
+pdf-anonymizer run notes.pdf --no-verify
+
+# Also ask the language model (slower)
+pdf-anonymizer run notes.pdf --verify-llm
+
+# Scan a file you already have
+pdf-anonymizer verify data/anonymized/notes.anonymized.md
+```
+
+This is a helper, not a lock. Read the report (and the page) before you share.
+
+---
+
 ## Limit national-ID regexes to some countries
 
 The first, fast search knows ID shapes for 30+ countries. On a US contract that is extra noise: a Polish PESEL or an Indian Aadhaar pattern can fire on a random digit string.

--- a/docs/project/troubleshooting.md
+++ b/docs/project/troubleshooting.md
@@ -44,6 +44,7 @@ Common problems and how to resolve them.
   - Use `--anonymized-entities` only if you intentionally want to restrict the types.
   - Check `app.log` — it shows how many entities were found by Regex vs LLM per chunk.
   - A number that *looks* like a card, IBAN, VIN, or national ID but fails the extra check-digit is still hidden, as `IBAN_LIKE_1` / `CREDIT_CARD_LIKE_1` and so on. That is expected for typos and example numbers such as `1234-5678-9012-3456`.
+  - After a run, check `data/stats/<stem>.residual_pii.json` (or `pdf-anonymizer verify …`). Leftover emails or numbers listed there were not hidden.
   - Very short documents or unusual formatting can reduce recall.
 
 ## LLM Returns Invalid JSON / Parsing Failures

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -62,7 +62,9 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
   [--prompt-name {simple|detailed}] \
   [--model-name TEXT] \
   [--anonymized-entities PATH] \
-  [--countries US,GB]
+  [--countries US,GB] \
+  [--verify / --no-verify] \
+  [--verify-llm]
 ```
 
 **Arguments**:
@@ -75,6 +77,10 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `--model-name TEXT`: The language model to use (overrides profile).
 - `--anonymized-entities PATH`: Path to a file with a list of entities to anonymize.
 - `--countries TEXT`: ISO-2 country codes for national-ID regexes, comma-separated (e.g. `US,GB`). Universal patterns (email, IBAN, cards, …) always stay. Default: all countries.
+- `--verify / --no-verify`: After masking, scan for leftovers (default: on). Writes `data/stats/<stem>.residual_pii.json`. Does not rewrite the file.
+- `--verify-llm`: Also ask the language model to hunt for leftovers.
+
+`pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 
 **Models**:
 You can use any of the predefined models below, or specify a new model using the format `"provider/model-name"`. 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.3.2"
+version = "0.4.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -21,6 +21,7 @@ from pdf_anonymizer_core.utils import (
     deanonymize_file,
     save_results,
 )
+from pdf_anonymizer_core.verify import verify_anonymized_text, write_residual_report
 from typing_extensions import Annotated
 
 # Setup logging using log file configured in conf.py
@@ -106,6 +107,24 @@ def run(
             ),
         ),
     ] = None,
+    verify: Annotated[
+        bool,
+        typer.Option(
+            "--verify/--no-verify",
+            help=(
+                "After masking, scan the result for leftover personal details "
+                "(cheap regex). Writes data/stats/<stem>.residual_pii.json. "
+                "Does not rewrite the file."
+            ),
+        ),
+    ] = True,
+    verify_llm: Annotated[
+        bool,
+        typer.Option(
+            "--verify-llm/--no-verify-llm",
+            help="Also ask the language model to hunt for leftovers (slower).",
+        ),
+    ] = False,
 ) -> None:
     """
     Anonymize one or more files by replacing PII with anonymized placeholders.
@@ -202,6 +221,24 @@ def run(
             logging.info(f"Anonymized text saved into '{anonymized_output_file}'")
             logging.info(f"Mapping vocabulary saved into '{mapping_file}'")
 
+            if verify or verify_llm:
+                report = verify_anonymized_text(
+                    full_anonymized_text,
+                    anonymized_file=anonymized_output_file,
+                    regex_patterns=config.regex_patterns,
+                    use_llm=verify_llm,
+                    model_name=config.model_name if verify_llm else None,
+                    max_retries=config.max_retries,
+                    base_retry_delay=config.base_retry_delay,
+                    max_retry_delay=config.max_retry_delay,
+                )
+                report_path = write_residual_report(report, anonymized_output_file)
+                logging.info(
+                    "Residual check: %s leftover hit(s). Report: %s",
+                    report["residual_count"],
+                    report_path,
+                )
+
 
 @app.command()
 def deanonymize(
@@ -240,6 +277,85 @@ def deanonymize(
     logging.info("Deanonymization complete!")
     logging.info(f"Deanonymized text saved into '{deanonymized_output_file}'")
     logging.info(f"Deanonymization statistics saved into '{stats_file}'")
+
+
+@app.command()
+def verify(
+    anonymized_file: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to an already anonymized file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    countries: Annotated[
+        Optional[str],
+        typer.Option(
+            "--countries",
+            help="ISO-2 country codes for the regex scan, comma-separated (e.g. US,GB).",
+        ),
+    ] = None,
+    verify_llm: Annotated[
+        bool,
+        typer.Option(
+            "--verify-llm/--no-verify-llm",
+            help="Also ask the language model to hunt for leftovers.",
+        ),
+    ] = False,
+    config_profile: Annotated[
+        ConfigProfile,
+        typer.Option(
+            "--config-profile",
+            "-p",
+            help="Profile used only when --verify-llm is set.",
+            case_sensitive=False,
+        ),
+    ] = ConfigProfile.BEST_SPEED,
+    model_name: Annotated[
+        Optional[str],
+        typer.Option(help="Override model when --verify-llm is set."),
+    ] = None,
+) -> None:
+    """Scan an anonymized file for leftover personal details. Does not rewrite it."""
+    load_environment()
+    country_list = None
+    if countries:
+        country_list = [part.strip() for part in countries.split(",") if part.strip()]
+
+    try:
+        config = get_config_for_profile(
+            profile=config_profile,
+            model_name=model_name,
+            countries=country_list,
+        )
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
+
+    text = anonymized_file.read_text(encoding="utf-8")
+    report = verify_anonymized_text(
+        text,
+        anonymized_file=str(anonymized_file),
+        regex_patterns=config.regex_patterns,
+        use_llm=verify_llm,
+        model_name=config.model_name if verify_llm else None,
+        max_retries=config.max_retries,
+        base_retry_delay=config.base_retry_delay,
+        max_retry_delay=config.max_retry_delay,
+    )
+    report_path = write_residual_report(report, str(anonymized_file))
+    logging.info(
+        "Residual check: %s leftover hit(s). Report: %s",
+        report["residual_count"],
+        report_path,
+    )
+    if report["residual_count"]:
+        for hit in report["regex_hits"] + report["llm_hits"]:
+            logging.info("  leftover %s: %s", hit["type"], hit["text"])
 
 
 if __name__ == "__main__":

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -115,6 +115,15 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+To scan a masked string for leftovers (report only, no rewrite):
+
+```python
+from pdf_anonymizer_core.verify import verify_anonymized_text, write_residual_report
+
+report = verify_anonymized_text(anonymized_text)
+write_residual_report(report, "data/anonymized/note.anonymized.md")
+```
+
 To keep only some countries' national-ID regexes (plus every universal pattern):
 
 ```python

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.3.2"
+version = "0.4.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
@@ -21,6 +21,11 @@ from pdf_anonymizer_core.conf import (
 _PLACEHOLDER_PATTERN = re.compile(r"^[A-Z_]+_[0-9]+(?:\.v_[0-9]+)?$")
 
 
+def looks_like_placeholder(text: str) -> bool:
+    """True if ``text`` is a stand-in label such as PERSON_1 or IBAN_LIKE_2."""
+    return bool(text and _PLACEHOLDER_PATTERN.match(text.strip()))
+
+
 def consolidate_mapping(
     anonymized_text: str, mapping: Dict[str, str]
 ) -> Tuple[str, Dict[str, str]]:

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/verify.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/verify.py
@@ -1,0 +1,153 @@
+"""Residual-PII scan for already-anonymized text.
+
+Re-runs the cheap regex pass on the masked document and optionally asks a
+language model to look again. Hits that are only stand-in labels (PERSON_1,
+IBAN_LIKE_2) are ignored. The scan reports; it does not rewrite the file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pdf_anonymizer_core.call_llm import identify_entities_with_llm
+from pdf_anonymizer_core.conf import DEFAULT_REGEX_PATTERNS, DEFAULT_STATS_DIR
+from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
+from pdf_anonymizer_core.utils import looks_like_placeholder
+
+RESIDUAL_LLM_PROMPT = """
+    You are checking an already-masked document for leftover personal details.
+    Ignore stand-in labels such as PERSON_1, ORGANIZATION_2, IBAN_LIKE_1, EMAIL_3.v_1.
+    List only real leftover values still written in the clear (names, emails,
+    phone numbers, IDs, addresses, identity clues).
+
+    Return a single JSON object with one key: "entities".
+    Each item must have "text", "type", and "base_form".
+
+    Text to check:
+    ---
+    {text}
+    ---
+
+    Respond with ONLY the JSON object.
+    """
+
+
+def _public_hit(entity: Dict[str, Any]) -> Dict[str, str]:
+    return {
+        "text": entity.get("text", ""),
+        "type": str(entity.get("type", "")).upper(),
+        "base_form": entity.get("base_form") or entity.get("text", ""),
+    }
+
+
+def scan_residual_regex(
+    text: str, regex_patterns: Optional[Dict[str, str]] = None
+) -> List[Dict[str, str]]:
+    """Return regex hits that are not stand-in labels."""
+    patterns = DEFAULT_REGEX_PATTERNS if regex_patterns is None else regex_patterns
+    hits: List[Dict[str, str]] = []
+    seen = set()
+    for entity in extract_entities_via_regex(text, patterns):
+        raw = entity["text"].strip()
+        if not raw or looks_like_placeholder(raw):
+            continue
+        key = (raw, entity["type"])
+        if key in seen:
+            continue
+        seen.add(key)
+        hits.append(_public_hit(entity))
+    return hits
+
+
+def scan_residual_llm(
+    text: str,
+    model_name: str,
+    prompt_template: str = RESIDUAL_LLM_PROMPT,
+    max_retries: int = 3,
+    base_retry_delay: float = 1.0,
+    max_retry_delay: float = 10.0,
+) -> List[Dict[str, str]]:
+    """Ask a language model for leftover personal details. May return []."""
+    raw_entities = identify_entities_with_llm(
+        text,
+        prompt_template,
+        model_name,
+        max_retries=max_retries,
+        base_retry_delay=base_retry_delay,
+        max_retry_delay=max_retry_delay,
+    )
+    hits: List[Dict[str, str]] = []
+    seen = set()
+    for entity in raw_entities:
+        raw = (entity.get("text") or "").strip()
+        if not raw or looks_like_placeholder(raw):
+            continue
+        key = (raw, str(entity.get("type", "")).upper())
+        if key in seen:
+            continue
+        seen.add(key)
+        hits.append(_public_hit(entity))
+    return hits
+
+
+def residual_report_path(anonymized_file_path: str) -> str:
+    """``data/stats/<stem>.residual_pii.json`` next to other stats files."""
+    anonymized_path = Path(anonymized_file_path)
+    file_stem = anonymized_path.name.replace(
+        f".anonymized{anonymized_path.suffix}", ""
+    )
+    if file_stem == anonymized_path.name:
+        file_stem = anonymized_path.stem
+    os.makedirs(DEFAULT_STATS_DIR, exist_ok=True)
+    return f"{DEFAULT_STATS_DIR}/{file_stem}.residual_pii.json"
+
+
+def verify_anonymized_text(
+    text: str,
+    *,
+    anonymized_file: Optional[str] = None,
+    regex_patterns: Optional[Dict[str, str]] = None,
+    use_llm: bool = False,
+    model_name: Optional[str] = None,
+    max_retries: int = 3,
+    base_retry_delay: float = 1.0,
+    max_retry_delay: float = 10.0,
+) -> Dict[str, Any]:
+    """Scan masked text. Never rewrites it.
+
+    Returns a report dict with regex_hits, optional llm_hits, and counts.
+    """
+    regex_hits = scan_residual_regex(text, regex_patterns)
+    llm_hits: List[Dict[str, str]] = []
+    if use_llm:
+        if not model_name:
+            raise ValueError("model_name is required when use_llm is True")
+        llm_hits = scan_residual_llm(
+            text,
+            model_name,
+            max_retries=max_retries,
+            base_retry_delay=base_retry_delay,
+            max_retry_delay=max_retry_delay,
+        )
+
+    report: Dict[str, Any] = {
+        "anonymized_file": anonymized_file,
+        "regex_hits": regex_hits,
+        "llm_hits": llm_hits,
+        "residual_count": len(regex_hits) + len(llm_hits),
+        "rewritten": False,
+    }
+    return report
+
+
+def write_residual_report(report: Dict[str, Any], anonymized_file_path: str) -> str:
+    """Write the report JSON and return its path."""
+    path = residual_report_path(anonymized_file_path)
+    report = dict(report)
+    report["anonymized_file"] = anonymized_file_path
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=4)
+    return path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,56 @@
+"""Residual-PII scan: report leftovers, never rewrite."""
+
+from pathlib import Path
+
+from pdf_anonymizer_core.utils import looks_like_placeholder
+from pdf_anonymizer_core.verify import (
+    scan_residual_regex,
+    verify_anonymized_text,
+    write_residual_report,
+)
+
+
+class TestLooksLikePlaceholder:
+    def test_typed_and_like_and_variation(self) -> None:
+        assert looks_like_placeholder("PERSON_1")
+        assert looks_like_placeholder("IBAN_LIKE_2")
+        assert looks_like_placeholder("ORGANIZATION_3.v_1")
+        assert not looks_like_placeholder("alice@example.com")
+        assert not looks_like_placeholder("DE89370400440532013000")
+
+
+class TestScanResidualRegex:
+    def test_finds_leftover_email_and_ignores_placeholders(self) -> None:
+        text = (
+            "Write PERSON_1 at leftover@example.com or use EMAIL_1. "
+            "IBAN_LIKE_1 is already masked."
+        )
+        hits = scan_residual_regex(text)
+        emails = [h for h in hits if h["type"] == "EMAIL"]
+        assert any(h["text"] == "leftover@example.com" for h in emails)
+        assert not any(looks_like_placeholder(h["text"]) for h in hits)
+
+    def test_finds_mistyped_iban_left_in_clear(self) -> None:
+        text = "Please pay GB00WEST12345698765432"
+        hits = scan_residual_regex(text)
+        types = {h["type"] for h in hits}
+        texts = {h["text"] for h in hits}
+        assert "GB00WEST12345698765432" in texts
+        assert "IBAN_LIKE" in types or "IBAN" in types
+
+
+class TestVerifyReport:
+    def test_report_does_not_rewrite_and_writes_json(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        text = "Contact leftover@example.com and PERSON_1"
+        report = verify_anonymized_text(text, anonymized_file="note.anonymized.md")
+        assert report["rewritten"] is False
+        assert report["residual_count"] >= 1
+        assert any(h["text"] == "leftover@example.com" for h in report["regex_hits"])
+        assert report["llm_hits"] == []
+
+        out = write_residual_report(report, "data/anonymized/note.anonymized.md")
+        path = Path(out)
+        assert path.name == "note.residual_pii.json"
+        assert path.is_file()
+        assert "leftover@example.com" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Hiding names is a first pass. A leftover email or a mistyped IBAN can still sit in the masked page.

After `run`, the tool re-scans the result with the cheap regex pass (unless `--no-verify`). It **does not rewrite** the file. It writes:

`data/stats/<stem>.residual_pii.json`

Stand-in labels such as `PERSON_1` or `IBAN_LIKE_1` are ignored. Real leftovers are listed.

`--verify-llm` also asks the language model. `pdf-anonymizer verify FILE` runs the same scan later.

`anonymize_file` return values are unchanged.

## How to try it

```bash
pdf-anonymizer run notes.pdf
pdf-anonymizer run notes.pdf --no-verify
pdf-anonymizer run notes.pdf --verify-llm
pdf-anonymizer verify data/anonymized/notes.anonymized.md
```

## Docs

Recipes: “Check the masked file for leftovers.” Also CLI usage, architecture, troubleshooting, both package READMEs.

This is plan item 4 from `docs/internal/improvement-plan.md` (not published on GitHub Pages).

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (81 tests).