### PR TITLE
feat: per-type operators (mask, hash, generalize, shift)

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -11,7 +11,7 @@
 - [x] 3. Country filter for regex patterns — done 2026-08-14, [PR #42](https://github.com/leo-gan/anonymizer/pull/42)
 - [x] 4. Residual-PII verification pass — done 2026-08-14, [PR #43](https://github.com/leo-gan/anonymizer/pull/43)
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
-- [ ] 6. Generalization and per-entity operators
+- [x] 6. Generalization and per-entity operators — done 2026-08-15, `feat/entity-operators`
 - [ ] 7. Quasi-identifier / linkage risk report
 - [ ] 8. HIPAA Safe Harbor entity profile
 
@@ -46,6 +46,7 @@ Known code facts to attach to:
 - `core.py`: replacement is whole-document string match, not character spans.
 - `prompts/detailed.py`: asks for identity clues (`INDIRECT`, or `PERSON` with a known `base_form`) plus birthdates; `simple.py` does not. Shipped in [PR #40](https://github.com/leo-gan/anonymizer/pull/40).
 - Mapping files are plaintext by default. `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY` writes `*.mapping.json.enc` (AES-256-GCM).
+- `--operator TYPE=mask|hash|generalize|shift` changes how a type is written. Default remains `replace` (PERSON_1).
 - National-ID regexes can be limited with `filter_regex_patterns(["US", "GB"])` or CLI `--countries US,GB`. Universal patterns always stay.
 
 ---
@@ -158,6 +159,8 @@ Known code facts to attach to:
 ---
 
 ### 6. Generalization and per-entity operators
+
+**Status:** done (2026-08-15) — `feat/entity-operators` (PR link after open)
 
 **Technique:** generalization (the mechanism behind *k*-anonymity and HIPAA Safe Harbor) plus Presidio/Philter-style operators.  
 **Why:** one strategy (`PERSON_1`) is wrong for every type. Cards should be masked, dates year-only, ZIPs truncated, SSNs never left reversible in a released file if the user does not want that.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -11,7 +11,7 @@
 - [x] 3. Country filter for regex patterns — done 2026-08-14, [PR #42](https://github.com/leo-gan/anonymizer/pull/42)
 - [x] 4. Residual-PII verification pass — done 2026-08-14, [PR #43](https://github.com/leo-gan/anonymizer/pull/43)
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
-- [x] 6. Generalization and per-entity operators — done 2026-08-15, `feat/entity-operators`
+- [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
 - [ ] 7. Quasi-identifier / linkage risk report
 - [ ] 8. HIPAA Safe Harbor entity profile
 
@@ -160,7 +160,7 @@ Known code facts to attach to:
 
 ### 6. Generalization and per-entity operators
 
-**Status:** done (2026-08-15) — `feat/entity-operators` (PR link after open)
+**Status:** done (2026-08-15) — [PR #45](https://github.com/leo-gan/anonymizer/pull/45) (`feat/entity-operators`)
 
 **Technique:** generalization (the mechanism behind *k*-anonymity and HIPAA Safe Harbor) plus Presidio/Philter-style operators.  
 **Why:** one strategy (`PERSON_1`) is wrong for every type. Cards should be masked, dates year-only, ZIPs truncated, SSNs never left reversible in a released file if the user does not want that.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -29,6 +29,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--verify` / `--no-verify` | flag | on | After masking, scan the result for leftovers (cheap regex). Writes `data/stats/<stem>.residual_pii.json`. Does not change the file. |
 | `--verify-llm` | flag | off | Also ask the language model to hunt for leftovers. |
 | `--mapping-passphrase` | `TEXT` | *none* | Lock the mapping as `*.mapping.json.enc` (AES-256-GCM). Also read from `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON. |
+| `--operator` | `TYPE=op` | `replace` | Repeatable. How to write a type: `replace`, `mask`, `hash`, `generalize`, `shift`. |
 
 ### Configuration Profiles
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -348,6 +348,33 @@ PDF Anonymizer is designed for files up to ~1 GB thanks to streaming chunking.
 
 ---
 
+## Choose how a type is written (mask, year, hash)
+
+By default every find becomes a stand-in such as `PERSON_1` or `CREDIT_CARD_2`. That is best for sending the page to another AI and putting names back later.
+
+Sometimes you want a different mark:
+
+| Operator | What the reader sees | Good for |
+|---|---|---|
+| `replace` | `PERSON_1` (default) | Reversible stand-ins |
+| `mask` | `****-****-****-1111` | Cards, SSNs, phones (keep a little shape) |
+| `generalize` | `2019`, `021**`, `40-49` | Dates, ZIP codes, ages |
+| `hash` | `H_` plus a short fingerprint | Same value always looks the same, but not readable |
+| `shift` | A nearby date | Dates that must stay dates, not just a year |
+
+```bash
+pdf-anonymizer run invoice.pdf \
+  --operator CREDIT_CARD=mask \
+  --operator DATE=generalize \
+  --operator DATE_ISO=generalize
+```
+
+Types you do not list stay as stand-ins. `CREDIT_CARD_LIKE` follows `CREDIT_CARD`.
+
+The mapping file still records how to put the original back when the written form is unique. Two dates that both become `2019` cannot both be restored uniquely.
+
+---
+
 ## Check the masked file for leftovers
 
 Hiding names is a first pass. A leftover email or a mistyped IBAN can still sit in the masked page.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -80,6 +80,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `--verify / --no-verify`: After masking, scan for leftovers (default: on). Writes `data/stats/<stem>.residual_pii.json`. Does not rewrite the file.
 - `--verify-llm`: Also ask the language model to hunt for leftovers.
 - `--mapping-passphrase TEXT`: Lock the mapping as `*.mapping.json.enc`. Also `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON.
+- `--operator TYPE=op`: How to write a type (`replace`, `mask`, `hash`, `generalize`, `shift`). Repeatable. Default is `replace`.
 
 `pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -16,6 +16,7 @@ from pdf_anonymizer_core.conf import (
 from pdf_anonymizer_core.core import anonymize_file
 from pdf_anonymizer_core.llm_provider import configure_cache
 from pdf_anonymizer_core.mapping_crypto import resolve_mapping_passphrase
+from pdf_anonymizer_core.operators import parse_operator_specs
 from pdf_anonymizer_core.prompts import detailed, simple
 from pdf_anonymizer_core.utils import (
     consolidate_mapping,
@@ -137,6 +138,16 @@ def run(
             ),
         ),
     ] = None,
+    operator: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--operator",
+            help=(
+                "How to write one type: TYPE=replace|mask|hash|generalize|shift. "
+                "Repeatable. Default for every type is replace (PERSON_1)."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Anonymize one or more files by replacing PII with anonymized placeholders.
@@ -156,6 +167,12 @@ def run(
             chunk_size=characters_to_anonymize,
             countries=country_list,
         )
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
+
+    try:
+        operator_map = parse_operator_specs(operator)
     except ValueError as exc:
         logging.error("%s", exc)
         sys.exit(1)
@@ -183,6 +200,8 @@ def run(
     if country_list:
         logging.info(f"  --countries: {country_list}")
         logging.info(f"  --regex-patterns: {len(config.regex_patterns)} after country filter")
+    if operator_map:
+        logging.info(f"  --operator: {operator_map}")
 
     # Select the appropriate prompt template
     prompt_templates: Dict[str, str] = {
@@ -214,6 +233,7 @@ def run(
             max_retries=config.max_retries,
             base_retry_delay=config.base_retry_delay,
             max_retry_delay=config.max_retry_delay,
+            operators=operator_map or None,
         )
 
         if full_anonymized_text and final_mapping:

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -116,6 +116,8 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`) go in `operators={"CREDIT_CARD": "mask"}` on `anonymize_file`.
+
 To scan a masked string for leftovers (report only, no rewrite):
 
 ```python

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Tuple
 from pdf_anonymizer_core.call_llm import identify_entities_with_llm
 from pdf_anonymizer_core.conf import DEFAULT_CHUNK_OVERLAP, DEFAULT_REGEX_PATTERNS
 from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
+from pdf_anonymizer_core.operators import apply_operator, operator_for_type
 from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
 from pdf_anonymizer_core.validators import LIKE_SUFFIX, parent_type, type_matches_filter
 
@@ -37,6 +38,7 @@ def anonymize_file(
     max_retries: int = 3,
     base_retry_delay: float = 1.0,
     max_retry_delay: float = 10.0,
+    operators: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
     """Anonymize a file by processing its text content.
 
@@ -71,6 +73,9 @@ def anonymize_file(
         max_retries: Maximum LLM call attempts per chunk (with exponential backoff).
         base_retry_delay: Base delay in seconds for retry backoff.
         max_retry_delay: Maximum delay cap for retry backoff.
+        operators: Optional map of entity type → operator (replace, mask, hash,
+            generalize, shift). Types not listed keep ``replace``. ``CREDIT_CARD_LIKE``
+            follows ``CREDIT_CARD``.
 
     Returns:
         A tuple (anonymized_text, mapping) where:
@@ -261,6 +266,30 @@ def anonymize_file(
             final_mapping[entity_text] = variation_placeholder
         else:
             final_mapping[entity_text] = main_placeholder
+
+    if operators:
+        text_to_type: Dict[str, str] = {}
+        text_to_base: Dict[str, str] = {}
+        for entity in entities_to_process:
+            entity_text = entity["text"]
+            entity_type = entity["type"].upper()
+            base_form = entity.get("base_form") or entity_text
+            text_to_type[entity_text] = entity_type
+            text_to_base[entity_text] = base_form
+            if base_form not in text_to_type:
+                text_to_type[base_form] = entity_type
+                text_to_base[base_form] = base_form
+        transformed: Dict[str, str] = {}
+        for original, placeholder in final_mapping.items():
+            entity_type = text_to_type.get(original, "ID")
+            transformed[original] = apply_operator(
+                original,
+                entity_type,
+                placeholder,
+                operator_for_type(entity_type, operators),
+                text_to_base.get(original, original),
+            )
+        final_mapping = transformed
 
     anonymized_text = full_text
     if entities_to_process:

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/operators.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/operators.py
@@ -1,0 +1,210 @@
+"""Per-type operators for how a found value is written into the masked file.
+
+Default is ``replace`` (typed stand-ins such as PERSON_1). Other operators
+change what the reader sees; the mapping still records original → written form
+so deanonymize can reverse when the written form is unique.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import date, datetime, timedelta
+from typing import Dict, Iterable, Optional
+
+from pdf_anonymizer_core.validators import parent_type
+
+OPERATOR_REPLACE = "replace"
+OPERATOR_MASK = "mask"
+OPERATOR_HASH = "hash"
+OPERATOR_GENERALIZE = "generalize"
+OPERATOR_SHIFT = "shift"
+
+OPERATORS = frozenset(
+    {
+        OPERATOR_REPLACE,
+        OPERATOR_MASK,
+        OPERATOR_HASH,
+        OPERATOR_GENERALIZE,
+        OPERATOR_SHIFT,
+    }
+)
+
+_ISO_DATE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+_US_ZIP = re.compile(r"^(\d{5})(?:-\d{4})?$")
+_ZIP_IN_TEXT = re.compile(r"\b(\d{5})(-\d{4})?\b")
+_DIGITS = re.compile(r"\d")
+
+
+def parse_operator_specs(specs: Optional[Iterable[str]]) -> Dict[str, str]:
+    """Parse ``TYPE=operator`` strings. Unknown operators raise ValueError."""
+    result: Dict[str, str] = {}
+    if not specs:
+        return result
+    for raw in specs:
+        if not raw or "=" not in raw:
+            raise ValueError(
+                f"Invalid --operator {raw!r}. Use TYPE=operator, e.g. CREDIT_CARD=mask."
+            )
+        type_name, operator = raw.split("=", 1)
+        type_name = type_name.strip().upper()
+        operator = operator.strip().lower()
+        if not type_name:
+            raise ValueError(f"Invalid --operator {raw!r}. Missing type name.")
+        if operator not in OPERATORS:
+            raise ValueError(
+                f"Unknown operator {operator!r} for {type_name}. "
+                f"Use one of: {', '.join(sorted(OPERATORS))}."
+            )
+        result[type_name] = operator
+    return result
+
+
+def operator_for_type(entity_type: str, operators: Optional[Dict[str, str]]) -> str:
+    """Resolve the operator for a type. ``CREDIT_CARD_LIKE`` follows ``CREDIT_CARD``."""
+    if not operators:
+        return OPERATOR_REPLACE
+    upper = entity_type.upper()
+    if upper in operators:
+        return operators[upper]
+    parent = parent_type(upper)
+    if parent in operators:
+        return operators[parent]
+    if upper.startswith("DATE") and "DATE" in operators:
+        return operators["DATE"]
+    return OPERATOR_REPLACE
+
+
+def apply_operator(
+    original: str,
+    entity_type: str,
+    placeholder: str,
+    operator: str,
+    base_form: Optional[str] = None,
+) -> str:
+    """Return the string to write in place of ``original``."""
+    if operator == OPERATOR_REPLACE:
+        return placeholder
+    if operator == OPERATOR_MASK:
+        return mask_value(original, entity_type)
+    if operator == OPERATOR_HASH:
+        return hash_value(original)
+    if operator == OPERATOR_GENERALIZE:
+        return generalize_value(original, entity_type)
+    if operator == OPERATOR_SHIFT:
+        return shift_date_value(original, base_form or original)
+    return placeholder
+
+
+def hash_value(original: str) -> str:
+    digest = hashlib.sha256(original.encode("utf-8")).hexdigest()[:16]
+    return f"H_{digest}"
+
+
+def mask_value(original: str, entity_type: str) -> str:
+    """Keep a little shape; hide the rest."""
+    kind = parent_type(entity_type)
+    digits = _DIGITS.findall(original)
+    if kind in {"CREDIT_CARD", "SSN", "SSN_US", "SIN_CA", "MEDICAL_NPI_US"} or (
+        kind.startswith("SSN")
+    ):
+        return _mask_keep_last(original, 4)
+    if kind == "IBAN" or kind.endswith("IBAN"):
+        return _mask_keep_last(original, 4)
+    if kind == "PHONE":
+        return _mask_keep_last(original, 4)
+    if kind == "EMAIL":
+        return _mask_email(original)
+    if digits and len(digits) >= 4:
+        return _mask_keep_last(original, 4)
+    return "".join("*" if ch.isalnum() else ch for ch in original) or "****"
+
+
+def _mask_keep_last(original: str, keep: int) -> str:
+    chars = list(original)
+    digit_positions = [i for i, ch in enumerate(chars) if ch.isdigit()]
+    hide = set(digit_positions[:-keep]) if len(digit_positions) > keep else set(digit_positions)
+    for i in hide:
+        chars[i] = "*"
+    letter_positions = [i for i, ch in enumerate(chars) if ch.isalpha()]
+    for i in letter_positions:
+        chars[i] = "*"
+    return "".join(chars)
+
+
+def _mask_email(original: str) -> str:
+    if "@" not in original:
+        return "*" * max(len(original), 4)
+    local, _, domain = original.partition("@")
+    local_out = (local[0] + "***") if local else "***"
+    if "." in domain:
+        name, _, tld = domain.rpartition(".")
+        domain_out = (name[0] + "***." + tld) if name else "***." + tld
+    else:
+        domain_out = (domain[0] + "***") if domain else "***"
+    return f"{local_out}@{domain_out}"
+
+
+def generalize_value(original: str, entity_type: str) -> str:
+    """Coarser value: year, ZIP3, or age band. Falls back to the original shape."""
+    kind = parent_type(entity_type)
+    parsed = _parse_date(original)
+    if parsed is not None and (
+        kind.startswith("DATE") or kind == "DATE" or _ISO_DATE.match(original.strip())
+    ):
+        return str(parsed.year)
+
+    zip_match = _US_ZIP.match(original.strip())
+    if zip_match:
+        return zip_match.group(1)[:3] + "**"
+
+    if kind == "ADDRESS":
+        return _ZIP_IN_TEXT.sub(lambda m: m.group(1)[:3] + "**", original)
+
+    if kind == "AGE" or (
+        kind in {"", "ID"} and original.strip().isdigit() and 1 <= int(original.strip()) <= 120
+    ):
+        return _age_band(int(original.strip()))
+
+    if original.strip().isdigit() and kind.startswith("DATE"):
+        # year-only already
+        return original.strip()
+
+    # Unknown shape: keep year if it looks like a date, else leave a coarse token
+    if parsed is not None:
+        return str(parsed.year)
+    return original
+
+
+def _age_band(age: int) -> str:
+    if age > 89:
+        return "90+"
+    low = (age // 10) * 10
+    return f"{low}-{low + 9}"
+
+
+def _parse_date(text: str) -> Optional[date]:
+    stripped = text.strip()
+    match = _ISO_DATE.match(stripped)
+    if match:
+        try:
+            return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        except ValueError:
+            return None
+    try:
+        return datetime.fromisoformat(stripped.replace("Z", "+00:00")).date()
+    except ValueError:
+        return None
+
+
+def shift_date_value(original: str, base_form: str) -> str:
+    """Shift a date by a stable offset derived from ``base_form``."""
+    parsed = _parse_date(original)
+    if parsed is None:
+        return original
+    digest = hashlib.sha256(f"pdf-anonymizer-date-shift:{base_form}".encode()).digest()
+    offset = int.from_bytes(digest[:2], "big") % 365 - 182
+    shifted = parsed + timedelta(days=offset)
+    # Preserve a trailing time suffix if the original had ISO time.
+    rest = original.strip()[10:] if len(original.strip()) > 10 else ""
+    return shifted.isoformat() + rest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,123 @@
+"""Per-type operators: replace, mask, hash, generalize, shift."""
+
+import pytest
+
+from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.operators import (
+    apply_operator,
+    generalize_value,
+    hash_value,
+    mask_value,
+    operator_for_type,
+    parse_operator_specs,
+    shift_date_value,
+)
+
+
+class TestParseSpecs:
+    def test_parses_and_rejects_bad(self) -> None:
+        assert parse_operator_specs(["CREDIT_CARD=mask", "DATE=generalize"]) == {
+            "CREDIT_CARD": "mask",
+            "DATE": "generalize",
+        }
+        with pytest.raises(ValueError, match="Unknown operator"):
+            parse_operator_specs(["PERSON=redact"])
+        with pytest.raises(ValueError, match="Invalid"):
+            parse_operator_specs(["PERSON"])
+
+
+class TestOperatorForType:
+    def test_like_and_date_follow_parent(self) -> None:
+        ops = {"CREDIT_CARD": "mask", "DATE": "generalize"}
+        assert operator_for_type("CREDIT_CARD_LIKE", ops) == "mask"
+        assert operator_for_type("DATE_ISO", ops) == "generalize"
+        assert operator_for_type("PERSON", ops) == "replace"
+
+
+class TestMaskHashGeneralizeShift:
+    def test_mask_card_keeps_last_four(self) -> None:
+        assert mask_value("4111 1111 1111 1111", "CREDIT_CARD").endswith("1111")
+        assert "4111" not in mask_value("4111 1111 1111 1111", "CREDIT_CARD")[:4]
+
+    def test_mask_email(self) -> None:
+        out = mask_value("ada@example.com", "EMAIL")
+        assert out.startswith("a")
+        assert "@" in out
+        assert "ada@" not in out
+
+    def test_hash_is_stable(self) -> None:
+        assert hash_value("Ada") == hash_value("Ada")
+        assert hash_value("Ada") != hash_value("Bob")
+        assert hash_value("Ada").startswith("H_")
+
+    def test_generalize_date_zip_age(self) -> None:
+        assert generalize_value("2019-06-20", "DATE_ISO") == "2019"
+        assert generalize_value("02139", "ZIP") == "021**"
+        assert generalize_value("47", "AGE") == "40-49"
+        assert generalize_value("91", "AGE") == "90+"
+        assert "021**" in generalize_value("123 Main St, Boston MA 02139", "ADDRESS")
+
+    def test_shift_is_stable_per_base_form(self) -> None:
+        a = shift_date_value("2019-06-20", "Ada Lovelace")
+        b = shift_date_value("2019-06-20", "Ada Lovelace")
+        c = shift_date_value("2019-06-20", "Someone Else")
+        assert a == b
+        assert a != "2019-06-20"
+        assert c != a
+        assert len(a) >= 10
+
+    def test_replace_returns_placeholder(self) -> None:
+        assert apply_operator("Ada", "PERSON", "PERSON_1", "replace") == "PERSON_1"
+
+
+class TestAnonymizeWithOperators:
+    def test_mask_card_in_document(self, mocker) -> None:
+        mocker.patch("os.path.getsize", return_value=0)
+        text = "Card 4111 1111 1111 1111"
+        mocker.patch(
+            "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+            return_value=(text, [text]),
+        )
+        mocker.patch("pdf_anonymizer_core.core.identify_entities_with_llm", return_value=[])
+        mocker.patch(
+            "pdf_anonymizer_core.core.extract_entities_via_regex",
+            return_value=[
+                {
+                    "text": "4111 1111 1111 1111",
+                    "type": "CREDIT_CARD",
+                    "base_form": "4111 1111 1111 1111",
+                }
+            ],
+        )
+        anonymized, mapping = anonymize_file(
+            "dummy.pdf",
+            1000,
+            "dummy",
+            "dummy",
+            operators={"CREDIT_CARD": "mask"},
+        )
+        assert "4111 1111 1111 1111" not in anonymized
+        assert anonymized.endswith("1111") or "1111" in anonymized
+        assert "CREDIT_CARD_1" not in anonymized
+        assert mapping["4111 1111 1111 1111"] != "CREDIT_CARD_1"
+
+    def test_default_is_still_replace(self, mocker) -> None:
+        mocker.patch("os.path.getsize", return_value=0)
+        text = "Hello Ada Lovelace"
+        mocker.patch(
+            "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+            return_value=(text, [text]),
+        )
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {"text": "Ada Lovelace", "type": "PERSON", "base_form": "Ada Lovelace"}
+            ],
+        )
+        mocker.patch(
+            "pdf_anonymizer_core.core.extract_entities_via_regex",
+            return_value=[],
+        )
+        anonymized, mapping = anonymize_file("dummy.pdf", 1000, "dummy", "dummy")
+        assert anonymized == "Hello PERSON_1"
+        assert mapping["Ada Lovelace"] == "PERSON_1"

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1150,7 +1150,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1198,7 +1198,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

One stand-in style is wrong for every type. Cards can keep a little shape. Dates can become a year.

Default is unchanged: `PERSON_1`, `CREDIT_CARD_2`.

```bash
pdf-anonymizer run invoice.pdf \
  --operator CREDIT_CARD=mask \
  --operator DATE=generalize \
  --operator DATE_ISO=generalize
```

| Operator | What the reader sees |
|---|---|
| `replace` | `PERSON_1` (default) |
| `mask` | `****-****-****-1111` |
| `generalize` | `2019`, `021**`, `40-49` |
| `hash` | `H_` plus a short fingerprint |
| `shift` | A nearby date (stable per person) |

`CREDIT_CARD_LIKE` follows `CREDIT_CARD`. Types you do not list stay as stand-ins.

The mapping still records how to put the original back when the written form is unique. Two dates that both become `2019` cannot both be restored uniquely.

Packages: **0.5.0 → 0.6.0**.

## Docs

Recipes: “Choose how a type is written.” Also CLI usage and both package READMEs.

This is plan item 6 from `docs/internal/improvement-plan.md` (not published on GitHub Pages).

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (100 tests).