### PR TITLE
feat: score identity-clue clumps in masked text

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -12,7 +12,7 @@
 - [x] 4. Residual-PII verification pass — done 2026-08-14, [PR #43](https://github.com/leo-gan/anonymizer/pull/43)
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
-- [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, `feat/linkage-risk-report`
+- [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
 - [ ] 8. HIPAA Safe Harbor entity profile
 
 ---
@@ -183,7 +183,7 @@ Known code facts to attach to:
 
 ### 7. Quasi-identifier / linkage risk report
 
-**Status:** done (2026-08-15) — `feat/linkage-risk-report` (PR link after open)
+**Status:** done (2026-08-15) — [PR #46](https://github.com/leo-gan/anonymizer/pull/46) (`feat/linkage-risk-report`)
 
 **Technique:** *k*-anonymity as a **diagnostic**, not a PDF rewriter. Sweeney, Dalenius, Netflix.
 

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -12,7 +12,7 @@
 - [x] 4. Residual-PII verification pass — done 2026-08-14, [PR #43](https://github.com/leo-gan/anonymizer/pull/43)
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
-- [ ] 7. Quasi-identifier / linkage risk report
+- [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, `feat/linkage-risk-report`
 - [ ] 8. HIPAA Safe Harbor entity profile
 
 ---
@@ -38,7 +38,7 @@ This product is a **reversible document pseudonymizer**: typed placeholders (`PE
 | *k*-anonymity / ℓ-diversity / *t*-closeness | Not implemented (tabular models; do not rewrite PDFs with them) |
 | Synthetic data | Not implemented |
 | Cryptographic methods | Mapping stored as plaintext |
-| Re-ID / attack simulation | Residual regex scan after `run` / `verify` (`data/stats/<stem>.residual_pii.json`); deanonymize stats still `unused` / `not_found` |
+| Re-ID / attack simulation | Residual regex scan + linkage-risk report (`*.residual_pii.json`, `*.risk.json`) |
 
 Known code facts to attach to:
 
@@ -182,6 +182,8 @@ Known code facts to attach to:
 ---
 
 ### 7. Quasi-identifier / linkage risk report
+
+**Status:** done (2026-08-15) — `feat/linkage-risk-report` (PR link after open)
 
 **Technique:** *k*-anonymity as a **diagnostic**, not a PDF rewriter. Sweeney, Dalenius, Netflix.
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -58,6 +58,10 @@ graph TD
     *   **Text/Fallback**: Uses `langchain_text_splitters.RecursiveCharacterTextSplitter`.
 *   This keeps individual requests within LLM token constraints and limits memory footprints.
 
+### Linkage-risk report
+*   After masking, the CLI scores clumps of stand-in types in the same passage (job + company + place).
+*   Result is `data/stats/<stem>.risk.json` (`high` / `medium` / `low`). The file is not rewritten. `pdf-anonymizer report` runs the same score later.
+
 ### Residual check (after replacement)
 *   The CLI re-runs the cheap regex pass on the masked text (unless `--no-verify`).
 *   Stand-in labels (`PERSON_1`, `IBAN_LIKE_1`) are ignored. Leftover emails or numbers are written to `data/stats/<stem>.residual_pii.json`.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -30,6 +30,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--verify-llm` | flag | off | Also ask the language model to hunt for leftovers. |
 | `--mapping-passphrase` | `TEXT` | *none* | Lock the mapping as `*.mapping.json.enc` (AES-256-GCM). Also read from `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON. |
 | `--operator` | `TYPE=op` | `replace` | Repeatable. How to write a type: `replace`, `mask`, `hash`, `generalize`, `shift`. |
+| `--risk` / `--no-risk` | flag | on | After masking, score identity-clue clumps. Writes `data/stats/<stem>.risk.json`. Does not change the file. |
 
 ### Configuration Profiles
 
@@ -95,6 +96,18 @@ To use any model not listed in the aliases, pass the string as `provider/model-n
 ```bash
 pdf-anonymizer run doc.pdf --model-name "google/gemini-2.0-flash-exp"
 ```
+
+---
+
+## The `report` Command (linkage risk)
+
+Score identity-clue clumps in an already-masked file. Does not change the file.
+
+```bash
+pdf-anonymizer report data/anonymized/notes.anonymized.md
+```
+
+The report is `data/stats/<stem>.risk.json`. `run` already writes this unless you pass `--no-risk`.
 
 ---
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -375,6 +375,30 @@ The mapping file still records how to put the original back when the written for
 
 ---
 
+## Score leftover identity clumps (linkage risk)
+
+Hiding names is not the same as hiding *who it is*. If the masked page still says `JOB_TITLE_1 of ORGANIZATION_1 in LOCATION_1`, a reader can often put the name back.
+
+After `run`, the tool scores those clumps (unless `--no-risk`). It **does not change the file**. It writes:
+
+`data/stats/<stem>.risk.json`
+
+Levels:
+
+- **high** — job + company + place, or a nameless identity phrase (`INDIRECT_1`), or three identity clues in one passage
+- **medium** — two clues together (person + city, person + company)
+- **low** — only one kind of clue, or none
+
+```bash
+pdf-anonymizer run notes.pdf
+pdf-anonymizer run notes.pdf --no-risk
+pdf-anonymizer report data/anonymized/notes.anonymized.md
+```
+
+This is a warning light, not a proof of safety. A `low` score does not mean the page is safe to publish.
+
+---
+
 ## Check the masked file for leftovers
 
 Hiding names is a first pass. A leftover email or a mistyped IBAN can still sit in the masked page.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -81,6 +81,9 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `--verify-llm`: Also ask the language model to hunt for leftovers.
 - `--mapping-passphrase TEXT`: Lock the mapping as `*.mapping.json.enc`. Also `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON.
 - `--operator TYPE=op`: How to write a type (`replace`, `mask`, `hash`, `generalize`, `shift`). Repeatable. Default is `replace`.
+- `--risk / --no-risk`: After masking, score identity-clue clumps (default: on). Writes `data/stats/<stem>.risk.json`.
+
+`pdf-anonymizer report FILE` runs the same linkage-risk score on an already-masked file.
 
 `pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -23,6 +23,7 @@ from pdf_anonymizer_core.utils import (
     deanonymize_file,
     save_results,
 )
+from pdf_anonymizer_core.risk import assess_linkage_risk, write_risk_report
 from pdf_anonymizer_core.verify import verify_anonymized_text, write_residual_report
 from typing_extensions import Annotated
 
@@ -148,6 +149,16 @@ def run(
             ),
         ),
     ] = None,
+    risk: Annotated[
+        bool,
+        typer.Option(
+            "--risk/--no-risk",
+            help=(
+                "After masking, score identity-clue clumps (job+company+place). "
+                "Writes data/stats/<stem>.risk.json. Does not change the file."
+            ),
+        ),
+    ] = True,
 ) -> None:
     """
     Anonymize one or more files by replacing PII with anonymized placeholders.
@@ -275,6 +286,17 @@ def run(
                     "Residual check: %s leftover hit(s). Report: %s",
                     report["residual_count"],
                     report_path,
+                )
+
+            if risk:
+                risk_report = assess_linkage_risk(full_anonymized_text)
+                risk_path = write_risk_report(risk_report, anonymized_output_file)
+                logging.info(
+                    "Linkage risk: %s (%s high / %s medium windows). Report: %s",
+                    risk_report["overall"],
+                    risk_report["high_count"],
+                    risk_report["medium_count"],
+                    risk_path,
                 )
 
 
@@ -410,6 +432,41 @@ def verify(
     if report["residual_count"]:
         for hit in report["regex_hits"] + report["llm_hits"]:
             logging.info("  leftover %s: %s", hit["type"], hit["text"])
+
+
+@app.command("report")
+def report_risk(
+    anonymized_file: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to an already anonymized file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+) -> None:
+    """Score identity-clue clumps in a masked file. Does not change the file."""
+    text = anonymized_file.read_text(encoding="utf-8")
+    risk_report = assess_linkage_risk(text)
+    risk_path = write_risk_report(risk_report, str(anonymized_file))
+    logging.info(
+        "Linkage risk: %s (%s high / %s medium windows). Report: %s",
+        risk_report["overall"],
+        risk_report["high_count"],
+        risk_report["medium_count"],
+        risk_path,
+    )
+    for window in risk_report["windows"]:
+        if window["level"] in {"high", "medium"}:
+            logging.info(
+                "  %s: %s — %s",
+                window["level"],
+                ", ".join(window["types"]),
+                window["reason"],
+            )
 
 
 if __name__ == "__main__":

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -118,6 +118,15 @@ See `conf.py`, `regex_ner.py`, and `validators.py`.
 
 Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`) go in `operators={"CREDIT_CARD": "mask"}` on `anonymize_file`.
 
+To score identity-clue clumps in masked text (report only):
+
+```python
+from pdf_anonymizer_core.risk import assess_linkage_risk, write_risk_report
+
+report = assess_linkage_risk(anonymized_text)
+write_risk_report(report, "data/anonymized/note.anonymized.md")
+```
+
 To scan a masked string for leftovers (report only, no rewrite):
 
 ```python

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.6.0"
+version = "0.7.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/risk.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/risk.py
@@ -1,0 +1,210 @@
+"""Linkage-risk report for already-masked text.
+
+A name can be gone and the page can still point to one person: job + company
++ city in the same paragraph. This module only *scores* those clumps. It does
+not change the file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+from pdf_anonymizer_core.conf import DEFAULT_STATS_DIR
+
+_PLACEHOLDER = re.compile(r"\b([A-Z][A-Z0-9_]*_[0-9]+(?:\.v_[0-9]+)?)\b")
+
+QUASI_TYPES = frozenset(
+    {
+        "PERSON",
+        "JOB_TITLE",
+        "ORGANIZATION",
+        "LOCATION",
+        "ADDRESS",
+        "DATE",
+        "DATE_ISO",
+        "AGE",
+        "INDIRECT",
+    }
+)
+
+_IDENTITY_CORE = frozenset(
+    {"PERSON", "JOB_TITLE", "ORGANIZATION", "LOCATION", "ADDRESS", "INDIRECT"}
+)
+
+HIGH_REASONS = {
+    "indirect": "A nameless phrase that still points to one person sits in this passage.",
+    "job_org_place": "A job, a company, and a place sit together (the 'CEO of Tesla in Austin' pattern).",
+    "person_org_place": "A person, a company, and a place sit together.",
+    "person_job_org": "A person, a job, and a company sit together.",
+    "three_clues": "Three or more identity clues sit in the same passage.",
+}
+
+LEVEL_ORDER = {"low": 1, "medium": 2, "high": 3}
+
+
+def placeholder_type(token: str) -> str:
+    """PERSON_1.v_2 → PERSON; IBAN_LIKE_1 → IBAN_LIKE."""
+    base = token.split(".v_")[0]
+    if "_" not in base:
+        return base
+    name, _, maybe_num = base.rpartition("_")
+    if maybe_num.isdigit():
+        return name
+    return base
+
+
+def _windows(text: str) -> List[str]:
+    parts = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not parts:
+        return [text] if text.strip() else []
+    # Split very long paragraphs so one wall of text is not one giant window.
+    windows: List[str] = []
+    for part in parts:
+        if len(part) <= 800:
+            windows.append(part)
+            continue
+        for i in range(0, len(part), 600):
+            chunk = part[i : i + 800].strip()
+            if chunk:
+                windows.append(chunk)
+    return windows
+
+
+def _score_types(types: Sequence[str]) -> Tuple[str, str]:
+    present = set(types)
+    quasi = present & QUASI_TYPES
+    core = present & _IDENTITY_CORE
+
+    if "INDIRECT" in quasi:
+        return "high", HIGH_REASONS["indirect"]
+    if {"JOB_TITLE", "ORGANIZATION", "LOCATION"} <= quasi:
+        return "high", HIGH_REASONS["job_org_place"]
+    if {"PERSON", "ORGANIZATION", "LOCATION"} <= quasi:
+        return "high", HIGH_REASONS["person_org_place"]
+    if {"PERSON", "JOB_TITLE", "ORGANIZATION"} <= quasi:
+        return "high", HIGH_REASONS["person_job_org"]
+    if len(core) >= 3:
+        return "high", HIGH_REASONS["three_clues"]
+    if len(core) >= 2 or (
+        "PERSON" in quasi and ({"DATE", "DATE_ISO", "AGE"} & quasi)
+    ):
+        return "medium", "Two identity clues sit in the same passage."
+    if quasi:
+        return "low", "Only one kind of identity clue is in this passage."
+    return "low", "No identity-clue combination in this passage."
+
+
+def assess_linkage_risk(text: str) -> Dict[str, Any]:
+    """Score identity-clue clumps in masked text. Does not rewrite it."""
+    findings: List[Dict[str, Any]] = []
+    overall = "low"
+    for excerpt in _windows(text):
+        tokens = _PLACEHOLDER.findall(excerpt)
+        if not tokens:
+            continue
+        types = sorted({placeholder_type(tok) for tok in tokens})
+        quasi_here = [t for t in types if t in QUASI_TYPES]
+        if not quasi_here:
+            continue
+        level, reason = _score_types(types)
+        if LEVEL_ORDER[level] > LEVEL_ORDER[overall]:
+            overall = level
+        findings.append(
+            {
+                "level": level,
+                "types": quasi_here,
+                "placeholders": sorted(set(tokens)),
+                "excerpt": excerpt if len(excerpt) <= 280 else excerpt[:277] + "...",
+                "reason": reason,
+            }
+        )
+
+    # Singleton combos (a set of placeholders that appear in only one window)
+    # stay at least medium — that is the "rare combination" signal.
+    combo_counts: Dict[Tuple[str, ...], int] = {}
+    for finding in findings:
+        key = tuple(sorted(finding["placeholders"]))
+        combo_counts[key] = combo_counts.get(key, 0) + 1
+    for finding in findings:
+        key = tuple(sorted(finding["placeholders"]))
+        if combo_counts.get(key, 0) == 1 and len(finding["types"]) >= 2:
+            if LEVEL_ORDER[finding["level"]] < LEVEL_ORDER["medium"]:
+                finding["level"] = "medium"
+                finding["reason"] = (
+                    "This mix of clues appears only once, so it is easier to pin on one person."
+                )
+            if LEVEL_ORDER[finding["level"]] > LEVEL_ORDER[overall]:
+                overall = finding["level"]
+
+    return {
+        "overall": overall,
+        "window_count": len(findings),
+        "high_count": sum(1 for f in findings if f["level"] == "high"),
+        "medium_count": sum(1 for f in findings if f["level"] == "medium"),
+        "low_count": sum(1 for f in findings if f["level"] == "low"),
+        "windows": findings,
+        "rewritten": False,
+    }
+
+
+def assess_entity_list(entities: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Score a flat entity list as one window (no positions). Does not rewrite."""
+    types = sorted(
+        {
+            str(ent.get("type", "")).upper()
+            for ent in entities
+            if ent.get("type")
+        }
+    )
+    if not types:
+        return {
+            "overall": "low",
+            "window_count": 0,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "windows": [],
+            "rewritten": False,
+        }
+    level, reason = _score_types(types)
+    texts = [str(ent.get("text", "")) for ent in entities if ent.get("text")]
+    finding = {
+        "level": level,
+        "types": [t for t in types if t in QUASI_TYPES],
+        "placeholders": [],
+        "excerpt": "; ".join(texts)[:280],
+        "reason": reason,
+    }
+    return {
+        "overall": level,
+        "window_count": 1,
+        "high_count": int(level == "high"),
+        "medium_count": int(level == "medium"),
+        "low_count": int(level == "low"),
+        "windows": [finding],
+        "rewritten": False,
+    }
+
+
+def risk_report_path(anonymized_file_path: str) -> str:
+    anonymized_path = Path(anonymized_file_path)
+    file_stem = anonymized_path.name.replace(
+        f".anonymized{anonymized_path.suffix}", ""
+    )
+    if file_stem == anonymized_path.name:
+        file_stem = anonymized_path.stem
+    os.makedirs(DEFAULT_STATS_DIR, exist_ok=True)
+    return f"{DEFAULT_STATS_DIR}/{file_stem}.risk.json"
+
+
+def write_risk_report(report: Dict[str, Any], anonymized_file_path: str) -> str:
+    path = risk_report_path(anonymized_file_path)
+    payload = dict(report)
+    payload["anonymized_file"] = anonymized_file_path
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=4)
+    return path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,69 @@
+"""Linkage-risk scoring on masked text. Does not rewrite."""
+
+from pathlib import Path
+
+from pdf_anonymizer_core.risk import (
+    assess_entity_list,
+    assess_linkage_risk,
+    placeholder_type,
+    write_risk_report,
+)
+
+
+class TestPlaceholderType:
+    def test_strips_index_and_variation(self) -> None:
+        assert placeholder_type("PERSON_1") == "PERSON"
+        assert placeholder_type("IBAN_LIKE_2") == "IBAN_LIKE"
+        assert placeholder_type("ORGANIZATION_3.v_1") == "ORGANIZATION"
+
+
+class TestAssessLinkageRisk:
+    def test_job_org_place_is_high(self) -> None:
+        text = (
+            "We met JOB_TITLE_1 of ORGANIZATION_1 at the office in LOCATION_1.\n\n"
+            "Later we had lunch."
+        )
+        report = assess_linkage_risk(text)
+        assert report["rewritten"] is False
+        assert report["overall"] == "high"
+        assert report["high_count"] >= 1
+        assert any(
+            {"JOB_TITLE", "ORGANIZATION", "LOCATION"} <= set(w["types"])
+            for w in report["windows"]
+        )
+
+    def test_indirect_is_high(self) -> None:
+        report = assess_linkage_risk("Please copy INDIRECT_1 on the filing.")
+        assert report["overall"] == "high"
+
+    def test_person_and_location_is_medium(self) -> None:
+        report = assess_linkage_risk("PERSON_1 lives in LOCATION_1.")
+        assert report["overall"] == "medium"
+
+    def test_lone_person_is_low(self) -> None:
+        report = assess_linkage_risk("PERSON_1 sat down.")
+        assert report["overall"] == "low"
+
+    def test_email_only_is_not_a_clump(self) -> None:
+        report = assess_linkage_risk("Write to EMAIL_1 please.")
+        assert report["overall"] == "low"
+        assert report["window_count"] == 0
+
+    def test_writes_json(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        report = assess_linkage_risk("PERSON_1 of ORGANIZATION_1 in LOCATION_1.")
+        path = write_risk_report(report, "data/anonymized/note.anonymized.md")
+        assert Path(path).name == "note.risk.json"
+        assert Path(path).is_file()
+        assert "high" in Path(path).read_text(encoding="utf-8")
+
+    def test_entity_list_helper(self) -> None:
+        report = assess_entity_list(
+            [
+                {"text": "CEO", "type": "JOB_TITLE"},
+                {"text": "Tesla", "type": "ORGANIZATION"},
+                {"text": "Austin", "type": "LOCATION"},
+            ]
+        )
+        assert report["overall"] == "high"
+        assert report["rewritten"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1150,7 +1150,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1198,7 +1198,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Hiding names is not the same as hiding *who it is*. If the masked page still says `JOB_TITLE_1 of ORGANIZATION_1 in LOCATION_1`, a reader can often put the name back.

After `run`, the tool scores those clumps (unless `--no-risk`). It **does not change the file**. It writes:

`data/stats/<stem>.risk.json`

- **high** — job + company + place, or `INDIRECT_1`, or three identity clues in one passage
- **medium** — two clues together (person + city, person + company)
- **low** — only one kind of clue, or none

```bash
pdf-anonymizer run notes.pdf
pdf-anonymizer report data/anonymized/notes.anonymized.md
```

A `low` score is not a proof of safety. This is a warning light.

Packages: **0.6.0 → 0.7.0**.

## Docs

Recipes: “Score leftover identity clumps.” Also CLI usage, architecture, both package READMEs.

This is plan item 7 from `docs/internal/improvement-plan.md` (not published on GitHub Pages).

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (108 tests).