### PR TITLE
feat: HIPAA Safe Harbor entity-profile coverage aid

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -13,7 +13,7 @@
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
-- [ ] 8. HIPAA Safe Harbor entity profile
+- [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, `feat/hipaa-entity-profile`
 
 ---
 
@@ -47,6 +47,7 @@ Known code facts to attach to:
 - `prompts/detailed.py`: asks for identity clues (`INDIRECT`, or `PERSON` with a known `base_form`) plus birthdates; `simple.py` does not. Shipped in [PR #40](https://github.com/leo-gan/anonymizer/pull/40).
 - Mapping files are plaintext by default. `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY` writes `*.mapping.json.enc` (AES-256-GCM).
 - `--operator TYPE=mask|hash|generalize|shift` changes how a type is written. Default remains `replace` (PERSON_1).
+- `--entity-profile hipaa-safe-harbor` is a coverage aid (year-only dates, ZIP3, age 90+). Not a compliance certificate.
 - National-ID regexes can be limited with `filter_regex_patterns(["US", "GB"])` or CLI `--countries US,GB`. Universal patterns always stay.
 
 ---
@@ -200,6 +201,8 @@ Known code facts to attach to:
 ---
 
 ### 8. HIPAA Safe Harbor entity profile
+
+**Status:** done (2026-08-15) — `feat/hipaa-entity-profile` (PR link after open)
 
 **Technique:** legal standard from the same history chapter (HIPAA 2003, 18 identifiers).  
 **Why:** `--anonymized-entities` is a raw type list. Health users need a named profile.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -13,7 +13,7 @@
 - [x] 5. Encrypted mapping file — done 2026-08-15, [PR #44](https://github.com/leo-gan/anonymizer/pull/44)
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
-- [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, `feat/hipaa-entity-profile`
+- [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
 
 ---
 
@@ -202,7 +202,7 @@ Known code facts to attach to:
 
 ### 8. HIPAA Safe Harbor entity profile
 
-**Status:** done (2026-08-15) — `feat/hipaa-entity-profile` (PR link after open)
+**Status:** done (2026-08-15) — [PR #47](https://github.com/leo-gan/anonymizer/pull/47) (`feat/hipaa-entity-profile`)
 
 **Technique:** legal standard from the same history chapter (HIPAA 2003, 18 identifiers).  
 **Why:** `--anonymized-entities` is a raw type list. Health users need a named profile.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -31,6 +31,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--mapping-passphrase` | `TEXT` | *none* | Lock the mapping as `*.mapping.json.enc` (AES-256-GCM). Also read from `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON. |
 | `--operator` | `TYPE=op` | `replace` | Repeatable. How to write a type: `replace`, `mask`, `hash`, `generalize`, `shift`. |
 | `--risk` / `--no-risk` | flag | on | After masking, score identity-clue clumps. Writes `data/stats/<stem>.risk.json`. Does not change the file. |
+| `--entity-profile` | `hipaa-safe-harbor` | *none* | Coverage aid for HIPAA Safe Harbor identifier classes. **Not a compliance certificate.** |
 
 ### Configuration Profiles
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -348,6 +348,26 @@ PDF Anonymizer is designed for files up to ~1 GB thanks to streaming chunking.
 
 ---
 
+## HIPAA Safe Harbor coverage aid
+
+Health notes mention more than names: visit dates, record numbers, small-area places, ages over 89.
+
+`--entity-profile hipaa-safe-harbor` is a **coverage aid**. It:
+
+- asks the careful prompt to look for the identifier *classes* that apply to text (the familiar list of 18 kinds: names, places smaller than a state, dates about a person, phones, emails, SSNs, record and plan numbers, licenses, vehicle and device IDs, URLs, IPs, and phrases for biometrics or face photos)
+- writes dates as a **year**, ZIP codes as **first three digits**, and ages over 89 as **90+**
+- does **not** hide pixels in a photo, and does **not** mean the file is legally de-identified
+
+This is **not** a HIPAA Safe Harbor certification. A person still has to read the result. Expert Determination is a different path and is not this flag.
+
+```bash
+pdf-anonymizer run clinic-note.pdf --entity-profile hipaa-safe-harbor
+```
+
+You can still add `--operator` (your choice wins) or `--anonymized-entities` (extra types are kept, not used to shrink the list).
+
+---
+
 ## Choose how a type is written (mask, year, hash)
 
 By default every find becomes a stand-in such as `PERSON_1` or `CREDIT_CARD_2`. That is best for sending the page to another AI and putting names back later.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -85,6 +85,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 
 `pdf-anonymizer report FILE` runs the same linkage-risk score on an already-masked file.
 
+- `--entity-profile hipaa-safe-harbor`: coverage aid for the 18 Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). **Not a compliance certificate.**
+
 `pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 
 **Models**:

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.7.0"
+version = "0.8.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -9,15 +9,18 @@ from dotenv import load_dotenv
 from pdf_anonymizer_core.conf import (
     DEFAULT_LOG_FILE,
     ConfigProfile,
+    EntityProfile,
     PromptEnum,
     get_config_for_profile,
     get_provider_and_model_name,
+    operators_for_entity_profile,
+    types_for_entity_profile,
 )
 from pdf_anonymizer_core.core import anonymize_file
 from pdf_anonymizer_core.llm_provider import configure_cache
 from pdf_anonymizer_core.mapping_crypto import resolve_mapping_passphrase
 from pdf_anonymizer_core.operators import parse_operator_specs
-from pdf_anonymizer_core.prompts import detailed, simple
+from pdf_anonymizer_core.prompts import detailed, hipaa, simple
 from pdf_anonymizer_core.utils import (
     consolidate_mapping,
     deanonymize_file,
@@ -159,6 +162,17 @@ def run(
             ),
         ),
     ] = True,
+    entity_profile: Annotated[
+        Optional[EntityProfile],
+        typer.Option(
+            "--entity-profile",
+            help=(
+                "Named type coverage bundle. hipaa-safe-harbor is an aid for "
+                "the 18 Safe Harbor identifier classes, not a compliance certificate."
+            ),
+            case_sensitive=False,
+        ),
+    ] = None,
 ) -> None:
     """
     Anonymize one or more files by replacing PII with anonymized placeholders.
@@ -225,8 +239,29 @@ def run(
     entities_to_anonymize = None
     if anonymized_entities:
         with open(anonymized_entities, "r") as f:
-            entities_to_anonymize = [line.strip() for line in f.readlines()]
+            entities_to_anonymize = [line.strip() for line in f.readlines() if line.strip()]
         logging.info(f"  --anonymized-entities: {entities_to_anonymize}")
+
+    if entity_profile is not None:
+        profile_types = types_for_entity_profile(entity_profile) or []
+        profile_ops = operators_for_entity_profile(entity_profile)
+        operator_map = {**profile_ops, **operator_map}
+        if entities_to_anonymize:
+            entities_to_anonymize = list(
+                dict.fromkeys([*profile_types, *entities_to_anonymize])
+            )
+        else:
+            entities_to_anonymize = profile_types
+        if (
+            entity_profile == EntityProfile.HIPAA_SAFE_HARBOR
+            and prompt_name is None
+        ):
+            prompt_template = hipaa.prompt_template
+        logging.info(
+            "  --entity-profile: %s (aid, not a compliance certificate)",
+            entity_profile.value,
+        )
+        logging.info("  --operator after profile: %s", operator_map)
 
     logging.info(f"Found {len(file_paths)} file(s) to process.")
 

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -116,6 +116,8 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+`EntityProfile.HIPAA_SAFE_HARBOR` is a coverage aid for Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). It is **not** a compliance certificate.
+
 Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`) go in `operators={"CREDIT_CARD": "mask"}` on `anonymize_file`.
 
 To score identity-clue clumps in masked text (report only):

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.7.0"
+version = "0.8.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
@@ -11,7 +11,7 @@ This module defines:
 """
 
 from enum import Enum
-from typing import Any, Dict, Iterable, Optional, Type, TypeVar
+from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -322,6 +322,68 @@ class ConfigProfile(str, Enum):
     BEST_QUALITY = "best-quality"
     BEST_SPEED = "best-speed"
     BEST_COST = "best-cost"
+
+
+class EntityProfile(str, Enum):
+    """Named type + operator bundles. Separate from quality/speed ConfigProfile."""
+
+    HIPAA_SAFE_HARBOR = "hipaa-safe-harbor"
+
+
+# Types and prefixes this profile tries to hide. Prefixes match
+# DRIVERS_LICENSE_US, DATE_ISO, etc. This is an aid, not a compliance certificate.
+HIPAA_SAFE_HARBOR_TYPES: List[str] = [
+    "PERSON",
+    "ADDRESS",
+    "LOCATION",
+    "DATE",
+    "DATE_ISO",
+    "AGE",
+    "PHONE",
+    "FAX",
+    "EMAIL",
+    "SSN",
+    "MEDICAL_RECORD",
+    "MEDICAL_NPI_US",
+    "MEDICAL_LICENSE",
+    "HEALTH_PLAN_ID",
+    "ACCOUNT",
+    "ID",
+    "DRIVERS_LICENSE",
+    "PASSPORT",
+    "VIN",
+    "MAC_ADDRESS",
+    "URL",
+    "IPV4_ADDRESS",
+    "IPV6_ADDRESS",
+    "IP_ADDRESS",
+    "DEVICE_ID",
+    "BIOMETRIC",
+    "PHOTO",
+    "ORGANIZATION",
+    "INDIRECT",
+    "CREDIT_CARD",
+    "IBAN",
+]
+
+HIPAA_SAFE_HARBOR_OPERATORS: Dict[str, str] = {
+    "DATE": "generalize",
+    "DATE_ISO": "generalize",
+    "ADDRESS": "generalize",
+    "AGE": "generalize",
+}
+
+
+def types_for_entity_profile(profile: Optional[EntityProfile]) -> Optional[List[str]]:
+    if profile == EntityProfile.HIPAA_SAFE_HARBOR:
+        return list(HIPAA_SAFE_HARBOR_TYPES)
+    return None
+
+
+def operators_for_entity_profile(profile: Optional[EntityProfile]) -> Dict[str, str]:
+    if profile == EntityProfile.HIPAA_SAFE_HARBOR:
+        return dict(HIPAA_SAFE_HARBOR_OPERATORS)
+    return {}
 
 
 # Centralized profiles dictionary

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/prompts/__init__.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/prompts/__init__.py
@@ -1,16 +1,18 @@
 """Prompt templates for the LLM anonymization stage.
 
-Exposes two ready-to-use templates:
+Exposes ready-to-use templates:
 
 - `detailed` : richer instructions, base_form support, more entity types,
   including INDIRECT (phrases that identify a person without naming them).
 - `simple`   : minimal, faster, lower token usage.
+- `hipaa`    : coverage aid for HIPAA Safe Harbor identifier classes.
+  Not a compliance certification.
 
 Example:
     from pdf_anonymizer_core.prompts import detailed
     prompt = detailed.prompt_template
 """
 
-from . import detailed, simple
+from . import detailed, hipaa, simple
 
-__all__ = ["detailed", "simple"]
+__all__ = ["detailed", "hipaa", "simple"]

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/prompts/hipaa.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/prompts/hipaa.py
@@ -1,0 +1,61 @@
+"""HIPAA Safe Harbor *aid* prompt.
+
+Asks for the identifier classes that apply to text (names, small-area geography,
+dates about a person, phones, emails, IDs, URLs, IPs, and so on).
+
+This is a helper for coverage. It is not a legal determination that the output
+meets the HIPAA Safe Harbor standard.
+"""
+
+prompt_template = """
+    You are helping hide health-related personal details in a document.
+    This is a coverage aid, not a legal certification.
+
+    Read the text and list every span that falls in the classes below.
+    Use exact text from the document.
+
+    Instructions:
+    1. Read the whole passage.
+    2. Mark names of people, and names of their relatives, employers, or household members.
+    3. Mark places smaller than a state: street, city, county, precinct, ZIP / postal code.
+       Leave a lone state name (e.g. "Texas") unless it is part of a full address.
+    4. Mark every date that relates to a person (birth, admission, discharge, death,
+       appointment, specimen). Do NOT skip non-birth dates. Use type DATE.
+    5. Mark ages. If someone is older than 89, still list the age text (type AGE).
+    6. Mark phone numbers and fax numbers (PHONE or FAX).
+    7. Mark email addresses (EMAIL).
+    8. Mark Social Security numbers and similar national IDs (SSN).
+    9. Mark medical record numbers (MEDICAL_RECORD), health-plan IDs (HEALTH_PLAN_ID),
+       account numbers (ACCOUNT), license numbers (DRIVERS_LICENSE or MEDICAL_LICENSE),
+       and other IDs (ID).
+    10. Mark vehicle IDs including VIN and plate-like tokens (VIN).
+    11. Mark device IDs (DEVICE_ID, MAC_ADDRESS).
+    12. Mark URLs (URL) and IP addresses (IPV4_ADDRESS or IPV6_ADDRESS).
+    13. If the text names a biometric (fingerprint, voiceprint, retina) or a face photo
+        caption, list that phrase as BIOMETRIC or PHOTO. You cannot hide pixels.
+    14. Mark identity clues that point to one person without a name as INDIRECT
+        (or PERSON with base_form if you know who it is).
+    15. Return one JSON object with key "entities". Each item needs "text", "type",
+        and "base_form".
+
+    Example:
+    Text: "Ada Lovelace, DOB 1815-12-10, MRN 998877, seen in Austin on 2020-03-04. Age 91."
+    Response:
+    {{
+        "entities": [
+            {{"text": "Ada Lovelace", "type": "PERSON", "base_form": "Ada Lovelace"}},
+            {{"text": "1815-12-10", "type": "DATE", "base_form": "1815-12-10"}},
+            {{"text": "MRN 998877", "type": "MEDICAL_RECORD", "base_form": "998877"}},
+            {{"text": "Austin", "type": "LOCATION", "base_form": "Austin"}},
+            {{"text": "2020-03-04", "type": "DATE", "base_form": "2020-03-04"}},
+            {{"text": "91", "type": "AGE", "base_form": "91"}}
+        ]
+    }}
+
+    Text to process:
+    ---
+    {text}
+    ---
+
+    Respond with ONLY the JSON object.
+    """

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/validators.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/validators.py
@@ -401,12 +401,22 @@ def parent_type(entity_type: str) -> str:
 
 
 def type_matches_filter(entity_type: str, allowed: list[str] | set[str]) -> bool:
-    """True if ``entity_type`` is listed, or is the ``_LIKE`` sibling of a listed type."""
+    """True if the type is listed, is a ``_LIKE`` sibling, or matches a prefix.
+
+    A listed ``DRIVERS_LICENSE`` matches ``DRIVERS_LICENSE_US``.
+    A listed ``DATE`` matches ``DATE_ISO``.
+    """
     allowed_upper = {item.upper() for item in allowed}
     upper = entity_type.upper()
-    if upper in allowed_upper:
+    parent = parent_type(upper)
+    if upper in allowed_upper or parent in allowed_upper:
         return True
-    return parent_type(upper) in allowed_upper
+    for item in allowed_upper:
+        if upper.startswith(item + "_") or parent.startswith(item + "_"):
+            return True
+        if upper.endswith("_" + item) or parent.endswith("_" + item):
+            return True
+    return False
 
 
 def passes_checksum(entity_type: str, text: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_entity_profile.py
+++ b/tests/test_entity_profile.py
@@ -1,0 +1,63 @@
+"""HIPAA Safe Harbor entity profile — coverage aid, not a certificate."""
+
+from pdf_anonymizer_core.conf import (
+    EntityProfile,
+    HIPAA_SAFE_HARBOR_OPERATORS,
+    operators_for_entity_profile,
+    types_for_entity_profile,
+)
+from pdf_anonymizer_core.operators import operator_for_type
+from pdf_anonymizer_core.prompts import hipaa
+from pdf_anonymizer_core.validators import type_matches_filter
+
+
+class TestHipaaProfile:
+    def test_covers_core_safe_harbor_classes(self) -> None:
+        types = types_for_entity_profile(EntityProfile.HIPAA_SAFE_HARBOR)
+        assert types is not None
+        needed = {
+            "PERSON",
+            "ADDRESS",
+            "DATE",
+            "PHONE",
+            "EMAIL",
+            "SSN",
+            "MEDICAL_RECORD",
+            "HEALTH_PLAN_ID",
+            "ACCOUNT",
+            "VIN",
+            "URL",
+            "IPV4_ADDRESS",
+            "BIOMETRIC",
+            "PHOTO",
+        }
+        assert needed <= set(types)
+
+    def test_generalizes_dates_address_age(self) -> None:
+        ops = operators_for_entity_profile(EntityProfile.HIPAA_SAFE_HARBOR)
+        assert ops["DATE"] == "generalize"
+        assert ops["DATE_ISO"] == "generalize"
+        assert ops["ADDRESS"] == "generalize"
+        assert ops["AGE"] == "generalize"
+        assert operator_for_type("DATE_ISO", {**HIPAA_SAFE_HARBOR_OPERATORS}) == "generalize"
+
+    def test_type_filter_includes_country_licenses(self) -> None:
+        types = types_for_entity_profile(EntityProfile.HIPAA_SAFE_HARBOR)
+        assert types is not None
+        assert type_matches_filter("DRIVERS_LICENSE_US", types)
+        assert type_matches_filter("US_PASSPORT", types)
+        assert type_matches_filter("SSN_US", types)
+        assert type_matches_filter("DATE_ISO", types)
+
+    def test_prompt_asks_for_more_than_birthdates(self) -> None:
+        text = hipaa.prompt_template
+        assert "birth" in text.lower()
+        assert "admission" in text.lower()
+        assert "MEDICAL_RECORD" in text
+        assert "BIOMETRIC" in text
+        assert "not a legal certification" in text.lower() or "not a legal" in text.lower()
+        assert "AGE" in text
+
+    def test_none_profile_is_a_no_op(self) -> None:
+        assert types_for_entity_profile(None) is None
+        assert operators_for_entity_profile(None) == {}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -107,3 +107,8 @@ class TestPassesChecksumDispatch:
         assert type_matches_filter("IBAN_LIKE", ["IBAN_LIKE"])
         assert not type_matches_filter("CREDIT_CARD", ["IBAN"])
         assert not type_matches_filter("PERSON", ["IBAN"])
+
+    def test_filter_matches_type_prefix(self) -> None:
+        assert type_matches_filter("DRIVERS_LICENSE_US", ["DRIVERS_LICENSE"])
+        assert type_matches_filter("DATE_ISO", ["DATE"])
+        assert not type_matches_filter("PERSON", ["PER"])

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1150,7 +1150,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1198,7 +1198,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

`--entity-profile hipaa-safe-harbor` is a **coverage aid** for the identifier classes that apply to text (the familiar Safe Harbor list of 18 kinds).

It:

- uses a dedicated prompt that looks for names, places smaller than a state, **all** dates about a person (not only birthdates), phones, emails, SSNs, record and plan numbers, licenses, vehicle and device IDs, URLs, IPs, and phrases for biometrics or face photos
- writes dates as a **year**, ZIP codes as **first three digits**, and ages over 89 as **90+**
- does **not** hide pixels in a photo

**This is not a HIPAA Safe Harbor certification.** A person still has to read the result. Expert Determination is a different path and is not this flag.

```bash
pdf-anonymizer run clinic-note.pdf --entity-profile hipaa-safe-harbor
```

Your own `--operator` values win. Extra types in `--anonymized-entities` are kept; they do not shrink the list.

Packages: **0.7.0 → 0.8.0**.

## Docs

Recipes: “HIPAA Safe Harbor coverage aid.” Also CLI usage and both package READMEs.

This is plan item 8 from `docs/internal/improvement-plan.md` (not published on GitHub Pages). The ordered plan is now complete.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (114 tests).