### PR TITLE
feat: add fake operator for stable synthetic replacements

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -14,6 +14,14 @@
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
+- [x] 9. Format-preserving synthetic replacements — done 2026-08-15, `feat/fake-operator`
+- [ ] 10. Cross-document consistent placeholders
+- [ ] 11. Allowlist / denylist gazetteers
+- [ ] 12. Span-based replacement
+- [ ] 13. TAB-style eval harness
+- [ ] 14. OCR for scanned PDFs
+- [ ] 15. In-place PDF redaction
+- [ ] 16. Regex-only / offline mode
 
 ---
 
@@ -221,20 +229,131 @@ Known code facts to attach to:
 
 ---
 
-## Suggested later (still independent)
+### 9. Format-preserving synthetic replacements
 
-Do not start these until 1–8 are done or explicitly re-prioritized.
+**Status:** done (2026-08-15) — `feat/fake-operator` (PR link after open)
 
-| Item | Notes |
-|---|---|
-| Format-preserving synthetic replacements | Seeded Faker keyed by `hash(secret, base_form, type)`. Cleaner as an operator on (6). |
-| Cross-document consistent placeholders | `--mapping-in existing.mapping.json` so `John Doe` is `PERSON_1` across a batch. |
-| Allowlist / denylist gazetteers | `--keep-list` / `--deny-list`. “Apple” the fruit vs “Apple Inc.” |
-| Span-based replacement | Carry `start`/`end`; replace intervals, longest-first. Makes (6) more correct. |
-| TAB-style eval harness | Mention-level and entity-level recall; split direct vs quasi identifiers. Tests/scripts only. |
-| OCR for scanned PDFs | Coverage gap; different stack. |
-| In-place PDF redaction | Different product surface (pixels / content streams), not Markdown export. |
-| Regex-only / offline mode | No LLM; useful for air-gapped structured PII. |
+**Technique:** synthetic data at *value* level, not whole-document GANs.  
+**Why:** Downstream readers (and LLMs) reason better over `Jane Alvarez` than `PERSON_1`. Raw values stay in the local mapping.
+
+**Do**
+
+- Add operator `fake`.
+- Seed with `hash(secret, base_form, type)` so the same person always gets the same fake.
+- Optional `--fake-secret` / `ANONYMIZER_FAKE_SECRET`. Default secret is a built-in constant (stable, not private).
+- Keep mapping original → fake so deanonymize still works.
+
+**Touches:** `operators.py`, `core.py`, CLI, recipes.  
+**Prerequisite:** none (builds on (6)).
+
+---
+
+### 10. Cross-document consistent placeholders
+
+**Technique:** pseudonymization for longitudinal studies.  
+**Why:** Batch mode treats each file alone. `John Doe` is `PERSON_1` in file A and `PERSON_7` in file B.
+
+**Do**
+
+- `--mapping-in existing.mapping.json` seeds placeholder counts and `base_entity_placeholders`.
+- Write an updated combined map.
+- Works with encrypted maps when a passphrase is set.
+
+**Touches:** `anonymize_file`, CLI.  
+**Prerequisite:** none.
+
+---
+
+### 11. Allowlist / denylist gazetteers
+
+**Technique:** foundational NER (deny-lists / keep-lists).  
+**Why:** “Apple” the fruit vs “Apple Inc.”; your own org name should stay visible.
+
+**Do**
+
+- `--keep-list` / `--deny-list` files (one phrase per line).
+- Keep-list skips replacement. Deny-list forces an entity even if regex/LLM missed it.
+
+**Touches:** merge step in `core.py`, CLI.  
+**Prerequisite:** none.
+
+---
+
+### 12. Span-based replacement
+
+**Technique:** engineering. Makes operators and generalization more correct.  
+**Why:** Global string replace can change `May` inside the wrong word. Regex `finditer` offsets are thrown away today.
+
+**Do**
+
+- Carry `start`/`end` (per chunk, mapped back to `full_text`).
+- Replace intervals, longest-first, no overlap.
+
+**Touches:** `regex_ner.py`, `core.py`, optional LLM offsets.  
+**Prerequisite:** none. Do not block other items on this.
+
+---
+
+### 13. TAB-style eval harness
+
+**Technique:** the open question in history.md: how do you measure leftover risk and utility?  
+**Why:** Unit tests cover regex and mapping, not privacy metrics. No recall split for direct vs quasi identifiers.
+
+**Do**
+
+- `tests/eval/` or `scripts/eval_tab.py` on a small fixture (or TAB if licensed).
+- Report mention-level and entity-level recall; split EMAIL/SSN vs LOCATION/DATE.
+- Tests/scripts only. No product behavior change.
+
+**Touches:** tests/scripts.  
+**Prerequisite:** none.
+
+---
+
+### 14. OCR for scanned PDFs
+
+**Technique:** coverage.  
+**Why:** Image-only PDFs yield empty text today (`pymupdf4llm` has nothing to read).
+
+**Do**
+
+- Optional OCR extra (e.g. Tesseract / ocrmypdf) behind a flag or extra.
+- Document that this is a new dependency and a quality/speed trade.
+
+**Touches:** `load_and_extract.py`, extras, recipes.  
+**Prerequisite:** none.
+
+---
+
+### 15. In-place PDF redaction
+
+**Technique:** different product surface.  
+**Why:** Today we export Markdown. Some users need black boxes on the original PDF (pixels / content streams).
+
+**Do**
+
+- Research PyMuPDF redaction annotations vs content-stream rewrite.
+- Keep Markdown export as default. In-place is opt-in.
+- Mapping must still round-trip if we claim reversibility.
+
+**Touches:** new output path, CLI `--output-pdf`.  
+**Prerequisite:** none. Large; design before coding if needed.
+
+---
+
+### 16. Regex-only / offline mode
+
+**Technique:** data removal without a language model.  
+**Why:** Air-gapped machines, cost, or structured logs where regex is enough.
+
+**Do**
+
+- `--no-llm` / profile that skips `identify_entities_with_llm`.
+- Still run checksums, country filter, operators, verify, risk.
+- Document that names and identity clues will be missed.
+
+**Touches:** `core.py`, CLI, recipes.  
+**Prerequisite:** none.
 
 ---
 
@@ -254,10 +373,9 @@ Do not start these until 1–8 are done or explicitly re-prioritized.
 
 Every numbered item can merge with **no prerequisite PR**. Soft couplings only:
 
-- (6) synthetic `fake` (later) is cleaner as an operator.
-- (8) is just config + prompt if (6) exists; without (6) it can still force type coverage.
-- (7) is more useful after (1).
-- Span-based replacement (later) makes (6) more correct; do not block (6) on it.
+- (9) `fake` is an operator on (6).
+- (12) makes (6) and (9) more correct; do not block them on it.
+- (10) is cleaner after (5) if the seed map is encrypted.
 
 ---
 

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -14,7 +14,7 @@
 - [x] 6. Generalization and per-entity operators — done 2026-08-15, [PR #45](https://github.com/leo-gan/anonymizer/pull/45)
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
-- [x] 9. Format-preserving synthetic replacements — done 2026-08-15, `feat/fake-operator`
+- [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
 - [ ] 10. Cross-document consistent placeholders
 - [ ] 11. Allowlist / denylist gazetteers
 - [ ] 12. Span-based replacement
@@ -231,7 +231,7 @@ Known code facts to attach to:
 
 ### 9. Format-preserving synthetic replacements
 
-**Status:** done (2026-08-15) — `feat/fake-operator` (PR link after open)
+**Status:** done (2026-08-15) — [PR #48](https://github.com/leo-gan/anonymizer/pull/48) (`feat/fake-operator`)
 
 **Technique:** synthetic data at *value* level, not whole-document GANs.  
 **Why:** Downstream readers (and LLMs) reason better over `Jane Alvarez` than `PERSON_1`. Raw values stay in the local mapping.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -29,7 +29,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--verify` / `--no-verify` | flag | on | After masking, scan the result for leftovers (cheap regex). Writes `data/stats/<stem>.residual_pii.json`. Does not change the file. |
 | `--verify-llm` | flag | off | Also ask the language model to hunt for leftovers. |
 | `--mapping-passphrase` | `TEXT` | *none* | Lock the mapping as `*.mapping.json.enc` (AES-256-GCM). Also read from `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON. |
-| `--operator` | `TYPE=op` | `replace` | Repeatable. How to write a type: `replace`, `mask`, `hash`, `generalize`, `shift`. |
+| `--operator` | `TYPE=op` | `replace` | Repeatable. How to write a type: `replace`, `mask`, `hash`, `generalize`, `shift`, `fake`. |
+| `--fake-secret` | `TEXT` | built-in | Seed for `fake`. Also `ANONYMIZER_FAKE_SECRET`. |
 | `--risk` / `--no-risk` | flag | on | After masking, score identity-clue clumps. Writes `data/stats/<stem>.risk.json`. Does not change the file. |
 | `--entity-profile` | `hipaa-safe-harbor` | *none* | Coverage aid for HIPAA Safe Harbor identifier classes. **Not a compliance certificate.** |
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -381,12 +381,16 @@ Sometimes you want a different mark:
 | `generalize` | `2019`, `021**`, `40-49` | Dates, ZIP codes, ages |
 | `hash` | `H_` plus a short fingerprint | Same value always looks the same, but not readable |
 | `shift` | A nearby date | Dates that must stay dates, not just a year |
+| `fake` | `Jane Alvarez`, `555-0103` | Looks real; same person always gets the same fake |
 
 ```bash
 pdf-anonymizer run invoice.pdf \
   --operator CREDIT_CARD=mask \
   --operator DATE=generalize \
   --operator DATE_ISO=generalize
+
+# Invent stable fake names (same person → same fake)
+pdf-anonymizer run notes.pdf --operator PERSON=fake --operator EMAIL=fake
 ```
 
 Types you do not list stay as stand-ins. `CREDIT_CARD_LIKE` follows `CREDIT_CARD`.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -80,7 +80,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `--verify / --no-verify`: After masking, scan for leftovers (default: on). Writes `data/stats/<stem>.residual_pii.json`. Does not rewrite the file.
 - `--verify-llm`: Also ask the language model to hunt for leftovers.
 - `--mapping-passphrase TEXT`: Lock the mapping as `*.mapping.json.enc`. Also `ANONYMIZER_MAPPING_KEY`. Default: plaintext JSON.
-- `--operator TYPE=op`: How to write a type (`replace`, `mask`, `hash`, `generalize`, `shift`). Repeatable. Default is `replace`.
+- `--operator TYPE=op`: How to write a type (`replace`, `mask`, `hash`, `generalize`, `shift`, `fake`). Repeatable. Default is `replace`.
+- `--fake-secret TEXT`: Seed for `fake`. Also `ANONYMIZER_FAKE_SECRET`.
 - `--risk / --no-risk`: After masking, score identity-clue clumps (default: on). Writes `data/stats/<stem>.risk.json`.
 
 `pdf-anonymizer report FILE` runs the same linkage-risk score on an already-masked file.

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -147,7 +147,7 @@ def run(
         typer.Option(
             "--operator",
             help=(
-                "How to write one type: TYPE=replace|mask|hash|generalize|shift. "
+                "How to write one type: TYPE=replace|mask|hash|generalize|shift|fake. "
                 "Repeatable. Default for every type is replace (PERSON_1)."
             ),
         ),
@@ -162,6 +162,16 @@ def run(
             ),
         ),
     ] = True,
+    fake_secret: Annotated[
+        Optional[str],
+        typer.Option(
+            "--fake-secret",
+            help=(
+                "Seed for --operator TYPE=fake. Also ANONYMIZER_FAKE_SECRET. "
+                "Same person always gets the same fake. Default is a built-in constant."
+            ),
+        ),
+    ] = None,
     entity_profile: Annotated[
         Optional[EntityProfile],
         typer.Option(
@@ -280,6 +290,7 @@ def run(
             base_retry_delay=config.base_retry_delay,
             max_retry_delay=config.max_retry_delay,
             operators=operator_map or None,
+            fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
         )
 
         if full_anonymized_text and final_mapping:

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -118,7 +118,7 @@ See `conf.py`, `regex_ner.py`, and `validators.py`.
 
 `EntityProfile.HIPAA_SAFE_HARBOR` is a coverage aid for Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). It is **not** a compliance certificate.
 
-Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`) go in `operators={"CREDIT_CARD": "mask"}` on `anonymize_file`.
+Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`, `fake`) go in `operators={"PERSON": "fake"}` on `anonymize_file`. Pass `fake_secret=` so the same person always gets the same fake.
 
 To score identity-clue clumps in masked text (report only):
 

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.8.0"
+version = "0.9.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }
@@ -12,6 +12,7 @@ dependencies = [
     "langchain-text-splitters",
     "google-re2",
     "cryptography>=50.0.0",
+    "faker>=40.36.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -39,6 +39,7 @@ def anonymize_file(
     base_retry_delay: float = 1.0,
     max_retry_delay: float = 10.0,
     operators: Optional[Dict[str, str]] = None,
+    fake_secret: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
     """Anonymize a file by processing its text content.
 
@@ -76,6 +77,8 @@ def anonymize_file(
         operators: Optional map of entity type → operator (replace, mask, hash,
             generalize, shift). Types not listed keep ``replace``. ``CREDIT_CARD_LIKE``
             follows ``CREDIT_CARD``.
+        fake_secret: Optional seed material for the ``fake`` operator. Same
+            person + type + secret always yields the same fake.
 
     Returns:
         A tuple (anonymized_text, mapping) where:
@@ -288,6 +291,7 @@ def anonymize_file(
                 placeholder,
                 operator_for_type(entity_type, operators),
                 text_to_base.get(original, original),
+                fake_secret or "",
             )
         final_mapping = transformed
 

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/operators.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/operators.py
@@ -19,6 +19,7 @@ OPERATOR_MASK = "mask"
 OPERATOR_HASH = "hash"
 OPERATOR_GENERALIZE = "generalize"
 OPERATOR_SHIFT = "shift"
+OPERATOR_FAKE = "fake"
 
 OPERATORS = frozenset(
     {
@@ -27,8 +28,11 @@ OPERATORS = frozenset(
         OPERATOR_HASH,
         OPERATOR_GENERALIZE,
         OPERATOR_SHIFT,
+        OPERATOR_FAKE,
     }
 )
+
+DEFAULT_FAKE_SECRET = "pdf-anonymizer-fake"
 
 _ISO_DATE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
 _US_ZIP = re.compile(r"^(\d{5})(?:-\d{4})?$")
@@ -81,6 +85,7 @@ def apply_operator(
     placeholder: str,
     operator: str,
     base_form: Optional[str] = None,
+    secret: str = "",
 ) -> str:
     """Return the string to write in place of ``original``."""
     if operator == OPERATOR_REPLACE:
@@ -93,7 +98,67 @@ def apply_operator(
         return generalize_value(original, entity_type)
     if operator == OPERATOR_SHIFT:
         return shift_date_value(original, base_form or original)
+    if operator == OPERATOR_FAKE:
+        return fake_value(original, entity_type, base_form or original, secret)
     return placeholder
+
+
+def _fake_seed(secret: str, entity_type: str, base_form: str) -> int:
+    material = f"{secret or DEFAULT_FAKE_SECRET}:{entity_type.upper()}:{base_form}"
+    return int(hashlib.sha256(material.encode("utf-8")).hexdigest()[:16], 16)
+
+
+def fake_value(
+    original: str,
+    entity_type: str,
+    base_form: str,
+    secret: str = "",
+) -> str:
+    """Stable fake in the same shape family. Same base_form always matches."""
+    from faker import Faker
+
+    kind = parent_type(entity_type)
+    fake = Faker("en_US")
+    fake.seed_instance(_fake_seed(secret, kind, base_form))
+
+    if kind == "PERSON":
+        return fake.name()
+    if kind == "EMAIL":
+        return fake.safe_email()
+    if kind == "PHONE" or kind == "FAX":
+        return f"555-010{fake.random_int(0, 9)}"
+    if kind == "LOCATION":
+        return fake.city()
+    if kind == "ADDRESS":
+        return fake.street_address()
+    if kind == "ORGANIZATION":
+        return fake.company()
+    if kind == "JOB_TITLE":
+        return fake.job()
+    if kind.startswith("DATE"):
+        parsed = _parse_date(original)
+        year = parsed.year if parsed else fake.random_int(1980, 2020)
+        return fake.date_between(
+            start_date=date(year, 1, 1), end_date=date(year, 12, 28)
+        ).isoformat()
+    if kind == "AGE":
+        return str(fake.random_int(21, 80))
+    if kind in {"CREDIT_CARD"} or kind.startswith("CREDIT_CARD"):
+        body = f"{_fake_seed(secret, kind, base_form):016d}"[:12]
+        return f"4111 {body[0:4]} {body[4:8]} {body[8:12]}"
+    if kind.startswith("SSN") or kind == "SIN_CA":
+        tail = f"{_fake_seed(secret, kind, base_form) % 10000:04d}"
+        return f"000-00-{tail}"
+    if kind == "IBAN" or kind.endswith("IBAN"):
+        tail = f"{_fake_seed(secret, kind, base_form) % 10**10:010d}"
+        return f"GB00FAKE{tail}"
+    if kind in {"IPV4_ADDRESS", "IP_ADDRESS"}:
+        return f"203.0.113.{_fake_seed(secret, kind, base_form) % 254 + 1}"
+    if kind == "URL":
+        return f"https://example.test/{fake.slug()}"
+    if kind == "VIN":
+        return f"1HGCM8263{fake.random_int(0, 9)}A{fake.random_int(100000, 999999)}"
+    return fake.word().title()
 
 
 def hash_value(original: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -5,6 +5,7 @@ import pytest
 from pdf_anonymizer_core.core import anonymize_file
 from pdf_anonymizer_core.operators import (
     apply_operator,
+    fake_value,
     generalize_value,
     hash_value,
     mask_value,
@@ -20,6 +21,7 @@ class TestParseSpecs:
             "CREDIT_CARD": "mask",
             "DATE": "generalize",
         }
+        assert parse_operator_specs(["PERSON=fake"]) == {"PERSON": "fake"}
         with pytest.raises(ValueError, match="Unknown operator"):
             parse_operator_specs(["PERSON=redact"])
         with pytest.raises(ValueError, match="Invalid"):
@@ -68,6 +70,23 @@ class TestMaskHashGeneralizeShift:
 
     def test_replace_returns_placeholder(self) -> None:
         assert apply_operator("Ada", "PERSON", "PERSON_1", "replace") == "PERSON_1"
+
+    def test_fake_is_stable_per_base_form_and_secret(self) -> None:
+        a = fake_value("Ada Lovelace", "PERSON", "Ada Lovelace", "s")
+        b = fake_value("Ada", "PERSON", "Ada Lovelace", "s")
+        c = fake_value("Ada Lovelace", "PERSON", "Ada Lovelace", "other")
+        d = fake_value("Bob", "PERSON", "Bob", "s")
+        assert a == b
+        assert a != c
+        assert a != d
+        assert a != "Ada Lovelace"
+        assert " " in a
+
+    def test_fake_email_and_phone_shape(self) -> None:
+        email = fake_value("ada@old.com", "EMAIL", "ada@old.com", "s")
+        phone = fake_value("555-1234", "PHONE", "555-1234", "s")
+        assert "@" in email
+        assert phone.startswith("555-010")
 
 
 class TestAnonymizeWithOperators:

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "40.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1133,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1150,10 +1162,11 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
+    { name = "faker" },
     { name = "google-re2" },
     { name = "langchain-text-splitters" },
     { name = "pymupdf4llm" },
@@ -1184,6 +1197,7 @@ openrouter = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'" },
     { name = "cryptography", specifier = ">=50.0.0" },
+    { name = "faker", specifier = ">=40.36.0" },
     { name = "google-genai", marker = "extra == 'google'" },
     { name = "google-re2" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'" },
@@ -1198,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1745,6 +1759,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Promotes the leftover “suggested later” work to numbered plan items **9–16**, and implements **item 9**.

`--operator PERSON=fake` writes a made-up name instead of `PERSON_1`. The same person (same `base_form` + type + secret) always gets the same fake. Raw values stay in the local mapping.

```bash
pdf-anonymizer run notes.pdf --operator PERSON=fake --operator EMAIL=fake
pdf-anonymizer run notes.pdf --operator PERSON=fake --fake-secret 'team-seed'
```

Phones use the `555-010x` range. Cards use a `4111` test prefix. SSNs use `000-00-xxxx` so they are obviously not real.

Packages: **0.8.0 → 0.9.0**. Adds the `faker` dependency on core.

## Plan items now numbered

9. Synthetic fakes (this PR)  
10. Cross-document consistent placeholders  
11. Allowlist / denylist gazetteers  
12. Span-based replacement  
13. TAB-style eval harness  
14. OCR for scanned PDFs  
15. In-place PDF redaction  
16. Regex-only / offline mode  

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (116 tests).