### PR TITLE
feat: reuse placeholders across documents

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -15,7 +15,7 @@
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
-- [ ] 10. Cross-document consistent placeholders
+- [x] 10. Cross-document consistent placeholders — done 2026-08-15, `feat/cross-document-placeholders`
 - [ ] 11. Allowlist / denylist gazetteers
 - [ ] 12. Span-based replacement
 - [ ] 13. TAB-style eval harness
@@ -249,6 +249,8 @@ Known code facts to attach to:
 ---
 
 ### 10. Cross-document consistent placeholders
+
+**Status:** done (2026-08-15) — `feat/cross-document-placeholders` (PR link after open)
 
 **Technique:** pseudonymization for longitudinal studies.  
 **Why:** Batch mode treats each file alone. `John Doe` is `PERSON_1` in file A and `PERSON_7` in file B.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -15,7 +15,7 @@
 - [x] 7. Quasi-identifier / linkage risk report — done 2026-08-15, [PR #46](https://github.com/leo-gan/anonymizer/pull/46)
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
-- [x] 10. Cross-document consistent placeholders — done 2026-08-15, `feat/cross-document-placeholders`
+- [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
 - [ ] 11. Allowlist / denylist gazetteers
 - [ ] 12. Span-based replacement
 - [ ] 13. TAB-style eval harness
@@ -250,7 +250,7 @@ Known code facts to attach to:
 
 ### 10. Cross-document consistent placeholders
 
-**Status:** done (2026-08-15) — `feat/cross-document-placeholders` (PR link after open)
+**Status:** done (2026-08-15) — [PR #49](https://github.com/leo-gan/anonymizer/pull/49) (`feat/cross-document-placeholders`)
 
 **Technique:** pseudonymization for longitudinal studies.  
 **Why:** Batch mode treats each file alone. `John Doe` is `PERSON_1` in file A and `PERSON_7` in file B.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -33,6 +33,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--fake-secret` | `TEXT` | built-in | Seed for `fake`. Also `ANONYMIZER_FAKE_SECRET`. |
 | `--risk` / `--no-risk` | flag | on | After masking, score identity-clue clumps. Writes `data/stats/<stem>.risk.json`. Does not change the file. |
 | `--entity-profile` | `hipaa-safe-harbor` | *none* | Coverage aid for HIPAA Safe Harbor identifier classes. **Not a compliance certificate.** |
+| `--mapping-in` | `PATH` | *none* | Seed stand-ins from an existing mapping so the same person stays `PERSON_1` across files. |
 
 ### Configuration Profiles
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -105,6 +105,23 @@ Do not put the passphrase in the document, the mapping, or the log.
 
 ---
 
+## Keep the same stand-in across files
+
+Each file used to start counting at `PERSON_1`. In a batch, Ada could be `PERSON_1` in notes.md and `PERSON_7` in contract.pdf.
+
+`--mapping-in` starts from an existing map. Files in the same `run` command also share the growing map, so Ada stays `PERSON_1` from the first file to the last.
+
+```bash
+pdf-anonymizer run day1.md day2.md
+# day2 reuses the people found in day1
+
+pdf-anonymizer run day3.md --mapping-in data/mappings/day2.mapping.json
+```
+
+Encrypted maps work if you also pass `--mapping-passphrase` (or `ANONYMIZER_MAPPING_KEY`). Each file's mapping file is the combined map up to that file.
+
+---
+
 ## Batch Processing Multiple Files
 
 The CLI accepts multiple input paths.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -87,6 +87,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 `pdf-anonymizer report FILE` runs the same linkage-risk score on an already-masked file.
 
 - `--entity-profile hipaa-safe-harbor`: coverage aid for the 18 Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). **Not a compliance certificate.**
+- `--mapping-in PATH`: reuse an existing mapping so the same person stays `PERSON_1` across files. Files in one `run` share the map automatically.
 
 `pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.9.0"
+version = "0.10.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -24,6 +24,7 @@ from pdf_anonymizer_core.prompts import detailed, hipaa, simple
 from pdf_anonymizer_core.utils import (
     consolidate_mapping,
     deanonymize_file,
+    load_seed_mapping,
     save_results,
 )
 from pdf_anonymizer_core.risk import assess_linkage_risk, write_risk_report
@@ -162,6 +163,21 @@ def run(
             ),
         ),
     ] = True,
+    mapping_in: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--mapping-in",
+            help=(
+                "Existing mapping file so the same person stays PERSON_1 "
+                "across documents. Also used as the starting map for a batch."
+            ),
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ] = None,
     fake_secret: Annotated[
         Optional[str],
         typer.Option(
@@ -275,6 +291,16 @@ def run(
 
     logging.info(f"Found {len(file_paths)} file(s) to process.")
 
+    seed_mapping = None
+    passphrase = resolve_mapping_passphrase(mapping_passphrase)
+    if mapping_in is not None:
+        try:
+            seed_mapping = load_seed_mapping(str(mapping_in), passphrase)
+        except ValueError as exc:
+            logging.error("%s", exc)
+            sys.exit(1)
+        logging.info("  --mapping-in: %s (%s entries)", mapping_in, len(seed_mapping))
+
     for i, file_path in enumerate(file_paths, 1):
         logging.info("=" * 40)
         logging.info(f"Processing file {i}/{len(file_paths)}: {file_path}")
@@ -291,9 +317,11 @@ def run(
             max_retry_delay=config.max_retry_delay,
             operators=operator_map or None,
             fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
+            seed_mapping=seed_mapping,
         )
 
         if full_anonymized_text and final_mapping:
+            seed_mapping = final_mapping
             # The mapping from anonymize_file is original -> placeholder.
             # We will standardize on placeholder -> original for subsequent steps.
             placeholder_to_original = {v: k for k, v in final_mapping.items()}
@@ -307,7 +335,7 @@ def run(
                 full_anonymized_text,
                 consolidated_placeholder_map,
                 str(file_path),
-                mapping_passphrase=resolve_mapping_passphrase(mapping_passphrase),
+                mapping_passphrase=passphrase,
             )
             logging.info(f"Anonymization for {file_path} complete!")
             logging.info(f"Anonymized text saved into '{anonymized_output_file}'")

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -116,6 +116,8 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+Pass `seed_mapping=` (original → written) into `anonymize_file` so the same person stays `PERSON_1` across documents. The CLI `--mapping-in` flag loads that file (including encrypted maps).
+
 `EntityProfile.HIPAA_SAFE_HARBOR` is a coverage aid for Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). It is **not** a compliance certificate.
 
 Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`, `fake`) go in `operators={"PERSON": "fake"}` on `anonymize_file`. Pass `fake_secret=` so the same person always gets the same fake.

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.9.0"
+version = "0.10.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -24,6 +24,7 @@ from pdf_anonymizer_core.conf import DEFAULT_CHUNK_OVERLAP, DEFAULT_REGEX_PATTER
 from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
 from pdf_anonymizer_core.operators import apply_operator, operator_for_type
 from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
+from pdf_anonymizer_core.utils import seed_placeholder_state
 from pdf_anonymizer_core.validators import LIKE_SUFFIX, parent_type, type_matches_filter
 
 
@@ -40,6 +41,7 @@ def anonymize_file(
     max_retry_delay: float = 10.0,
     operators: Optional[Dict[str, str]] = None,
     fake_secret: Optional[str] = None,
+    seed_mapping: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
     """Anonymize a file by processing its text content.
 
@@ -79,6 +81,8 @@ def anonymize_file(
             follows ``CREDIT_CARD``.
         fake_secret: Optional seed material for the ``fake`` operator. Same
             person + type + secret always yields the same fake.
+        seed_mapping: Optional original → written map from a previous file so
+            the same person keeps PERSON_1 (or the same fake) across documents.
 
     Returns:
         A tuple (anonymized_text, mapping) where:
@@ -226,6 +230,8 @@ def anonymize_file(
 
     # Consolidate base forms to handle variations like "John" vs "John Doe"
     base_forms = {e.get("base_form") for e in entities_to_process if e.get("base_form")}
+    if seed_mapping:
+        base_forms.update(seed_mapping.keys())
     sorted_base_forms = sorted(list(base_forms), key=len, reverse=True)
     for entity in entities_to_process:
         base_form = entity.get("base_form")
@@ -236,11 +242,19 @@ def anonymize_file(
                 entity["base_form"] = potential_full_form
                 break
 
-    # Generate placeholders
-    final_mapping: Dict[str, str] = {}
-    placeholder_counts: Dict[str, int] = {}
-    base_entity_placeholders: Dict[str, str] = {}
-    variation_counters: Dict[str, int] = {}
+    # Generate placeholders (optionally seeded from a previous document)
+    if seed_mapping:
+        (
+            final_mapping,
+            base_entity_placeholders,
+            placeholder_counts,
+            variation_counters,
+        ) = seed_placeholder_state(seed_mapping)
+    else:
+        final_mapping = {}
+        placeholder_counts = {}
+        base_entity_placeholders = {}
+        variation_counters = {}
 
     for entity in entities_to_process:
         entity_text = entity["text"]
@@ -282,8 +296,12 @@ def anonymize_file(
             if base_form not in text_to_type:
                 text_to_type[base_form] = entity_type
                 text_to_base[base_form] = base_form
+        seeded_originals = set(seed_mapping) if seed_mapping else set()
         transformed: Dict[str, str] = {}
         for original, placeholder in final_mapping.items():
+            if original in seeded_originals:
+                transformed[original] = placeholder
+                continue
             entity_type = text_to_type.get(original, "ID")
             transformed[original] = apply_operator(
                 original,

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from pdf_anonymizer_core.conf import (
     DEFAULT_ANONYMIZED_DIR,
@@ -28,6 +28,63 @@ _PLACEHOLDER_PATTERN = re.compile(r"^[A-Z_]+_[0-9]+(?:\.v_[0-9]+)?$")
 def looks_like_placeholder(text: str) -> bool:
     """True if ``text`` is a stand-in label such as PERSON_1 or IBAN_LIKE_2."""
     return bool(text and _PLACEHOLDER_PATTERN.match(text.strip()))
+
+
+_PLACEHOLDER_PARSE = re.compile(r"^([A-Z][A-Z0-9_]*)_([0-9]+)(?:\.v_([0-9]+))?$")
+
+
+def mapping_to_original_to_written(raw: Dict[str, str]) -> Dict[str, str]:
+    """Accept either placeholder→original or original→placeholder."""
+    keys_ph = sum(1 for key in raw if isinstance(key, str) and looks_like_placeholder(key))
+    vals_ph = sum(
+        1 for val in raw.values() if isinstance(val, str) and looks_like_placeholder(val)
+    )
+    if keys_ph >= vals_ph:
+        out: Dict[str, str] = {}
+        for placeholder, original in raw.items():
+            if isinstance(original, str) and isinstance(placeholder, str):
+                out.setdefault(original, placeholder)
+        return out
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def load_seed_mapping(
+    mapping_path: str, mapping_passphrase: Optional[str] = None
+) -> Dict[str, str]:
+    """Load a mapping file as original → written form (placeholder or fake)."""
+    with open(mapping_path, "r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+    loaded = load_mapping_payload(raw, mapping_passphrase)
+    return mapping_to_original_to_written(loaded)
+
+
+def seed_placeholder_state(
+    orig_to_written: Dict[str, str],
+) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, int], Dict[str, int]]:
+    """Turn an existing original→written map into placeholder assignment state."""
+    mapping = dict(orig_to_written)
+    base_placeholders: Dict[str, str] = {}
+    counts: Dict[str, int] = {}
+    variation_counts: Dict[str, int] = {}
+    for original, written in mapping.items():
+        if not isinstance(written, str):
+            continue
+        parsed = _PLACEHOLDER_PARSE.match(written)
+        if not parsed:
+            base_placeholders[original] = written
+            continue
+        type_name, number, variation = (
+            parsed.group(1),
+            int(parsed.group(2)),
+            parsed.group(3),
+        )
+        counts[type_name] = max(counts.get(type_name, 0), number)
+        main = f"{type_name}_{number}"
+        if variation is None:
+            base_placeholders[original] = main
+        else:
+            variation_counts[main] = max(variation_counts.get(main, 0), int(variation))
+    return mapping, base_placeholders, counts, variation_counts
 
 
 def consolidate_mapping(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_seed_mapping.py
+++ b/tests/test_seed_mapping.py
@@ -1,0 +1,69 @@
+"""Cross-document placeholder seeding."""
+
+import json
+from pathlib import Path
+
+from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.mapping_crypto import encrypt_mapping
+from pdf_anonymizer_core.utils import load_seed_mapping, seed_placeholder_state
+
+
+def test_seed_state_reads_counts_and_variations() -> None:
+    orig_to_written = {
+        "Ada Lovelace": "PERSON_1",
+        "Ada": "PERSON_1.v_1",
+        "Acme Inc.": "ORGANIZATION_3",
+    }
+    mapping, bases, counts, variations = seed_placeholder_state(orig_to_written)
+    assert mapping["Ada Lovelace"] == "PERSON_1"
+    assert bases["Ada Lovelace"] == "PERSON_1"
+    assert counts["PERSON"] == 1
+    assert counts["ORGANIZATION"] == 3
+    assert variations["PERSON_1"] == 1
+
+
+def test_load_seed_mapping_accepts_placeholder_to_original(tmp_path: Path) -> None:
+    path = tmp_path / "m.json"
+    path.write_text(json.dumps({"PERSON_1": "Ada Lovelace"}), encoding="utf-8")
+    loaded = load_seed_mapping(str(path))
+    assert loaded == {"Ada Lovelace": "PERSON_1"}
+
+
+def test_load_seed_mapping_encrypted(tmp_path: Path) -> None:
+    path = tmp_path / "m.json.enc"
+    path.write_text(
+        json.dumps(encrypt_mapping({"PERSON_1": "Ada Lovelace"}, "secret")),
+        encoding="utf-8",
+    )
+    loaded = load_seed_mapping(str(path), "secret")
+    assert loaded == {"Ada Lovelace": "PERSON_1"}
+
+
+def test_second_file_reuses_person_1(mocker) -> None:
+    mocker.patch("os.path.getsize", return_value=0)
+    text = "Ada Lovelace met Jane Smith."
+    mocker.patch(
+        "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+        return_value=(text, [text]),
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.identify_entities_with_llm",
+        return_value=[
+            {"text": "Ada Lovelace", "type": "PERSON", "base_form": "Ada Lovelace"},
+            {"text": "Jane Smith", "type": "PERSON", "base_form": "Jane Smith"},
+        ],
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.extract_entities_via_regex",
+        return_value=[],
+    )
+    anonymized, mapping = anonymize_file(
+        "dummy.pdf",
+        1000,
+        "dummy",
+        "dummy",
+        seed_mapping={"Ada Lovelace": "PERSON_1"},
+    )
+    assert mapping["Ada Lovelace"] == "PERSON_1"
+    assert mapping["Jane Smith"] == "PERSON_2"
+    assert anonymized == "PERSON_1 met PERSON_2."

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Each file used to start counting at `PERSON_1`. In a batch, Ada could be `PERSON_1` in notes.md and `PERSON_7` in contract.pdf.

`--mapping-in` starts from an existing map. Files in the same `run` command also share the growing map.

```bash
pdf-anonymizer run day1.md day2.md
pdf-anonymizer run day3.md --mapping-in data/mappings/day2.mapping.json
```

Encrypted maps work with `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY`. Each file's mapping file is the combined map up to that file.

Packages: **0.9.0 → 0.10.0**.

## Docs

Recipes: “Keep the same stand-in across files.” Also CLI usage and both package READMEs.

This is plan item 10 from `docs/internal/improvement-plan.md`.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (120 tests).