### PR TITLE
feat: keep-list and deny-list gazetteers

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -16,7 +16,7 @@
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
-- [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, `feat/keep-deny-lists`
+- [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, [PR #50](https://github.com/leo-gan/anonymizer/pull/50)
 - [ ] 12. Span-based replacement
 - [ ] 13. TAB-style eval harness
 - [ ] 14. OCR for scanned PDFs
@@ -268,7 +268,7 @@ Known code facts to attach to:
 
 ### 11. Allowlist / denylist gazetteers
 
-**Status:** done (2026-08-15) — `feat/keep-deny-lists` (PR link after open)
+**Status:** done (2026-08-15) — [PR #50](https://github.com/leo-gan/anonymizer/pull/50) (`feat/keep-deny-lists`)
 
 **Technique:** foundational NER (deny-lists / keep-lists).  
 **Why:** “Apple” the fruit vs “Apple Inc.”; your own org name should stay visible.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -16,7 +16,7 @@
 - [x] 8. HIPAA Safe Harbor entity profile — done 2026-08-15, [PR #47](https://github.com/leo-gan/anonymizer/pull/47)
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
-- [ ] 11. Allowlist / denylist gazetteers
+- [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, `feat/keep-deny-lists`
 - [ ] 12. Span-based replacement
 - [ ] 13. TAB-style eval harness
 - [ ] 14. OCR for scanned PDFs
@@ -267,6 +267,8 @@ Known code facts to attach to:
 ---
 
 ### 11. Allowlist / denylist gazetteers
+
+**Status:** done (2026-08-15) — `feat/keep-deny-lists` (PR link after open)
 
 **Technique:** foundational NER (deny-lists / keep-lists).  
 **Why:** “Apple” the fruit vs “Apple Inc.”; your own org name should stay visible.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -34,6 +34,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 | `--risk` / `--no-risk` | flag | on | After masking, score identity-clue clumps. Writes `data/stats/<stem>.risk.json`. Does not change the file. |
 | `--entity-profile` | `hipaa-safe-harbor` | *none* | Coverage aid for HIPAA Safe Harbor identifier classes. **Not a compliance certificate.** |
 | `--mapping-in` | `PATH` | *none* | Seed stand-ins from an existing mapping so the same person stays `PERSON_1` across files. |
+| `--keep-list` | `PATH` | *none* | Phrases to leave visible (one per line). Wins if also on the deny-list. |
+| `--deny-list` | `PATH` | *none* | Phrases that must be hidden even if detection missed them. |
 
 ### Configuration Profiles
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -105,6 +105,28 @@ Do not put the passphrase in the document, the mapping, or the log.
 
 ---
 
+## Keep some phrases, always hide others
+
+A keep-list is a file of phrases that must stay visible, even if the tool found them. Use this for your own company name, or for “Apple” when you mean the fruit.
+
+A deny-list is a file of phrases that must be hidden, even if regex and the model missed them.
+
+One phrase per line. Lines starting with `#` are comments. If a phrase is on both lists, **keep wins**.
+
+```text
+# keep.txt
+Apple
+Acme Inc.
+```
+
+```bash
+pdf-anonymizer run notes.pdf --keep-list keep.txt --deny-list must-hide.txt
+```
+
+Deny-list hits become `CUSTOM_1`, `CUSTOM_2`, and so on.
+
+---
+
 ## Keep the same stand-in across files
 
 Each file used to start counting at `PERSON_1`. In a batch, Ada could be `PERSON_1` in notes.md and `PERSON_7` in contract.pdf.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -88,6 +88,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 
 - `--entity-profile hipaa-safe-harbor`: coverage aid for the 18 Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). **Not a compliance certificate.**
 - `--mapping-in PATH`: reuse an existing mapping so the same person stays `PERSON_1` across files. Files in one `run` share the map automatically.
+- `--keep-list PATH`: phrases to leave visible (one per line).
+- `--deny-list PATH`: phrases that must be hidden even if detection missed them.
 
 `pdf-anonymizer verify FILE` runs the same leftover scan on an already-masked file.
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.10.0"
+version = "0.11.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -17,6 +17,7 @@ from pdf_anonymizer_core.conf import (
     types_for_entity_profile,
 )
 from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.gazetteers import load_phrase_list
 from pdf_anonymizer_core.llm_provider import configure_cache
 from pdf_anonymizer_core.mapping_crypto import resolve_mapping_passphrase
 from pdf_anonymizer_core.operators import parse_operator_specs
@@ -163,6 +164,30 @@ def run(
             ),
         ),
     ] = True,
+    keep_list: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--keep-list",
+            help="Phrases to leave visible (one per line). Wins over --deny-list.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ] = None,
+    deny_list: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--deny-list",
+            help="Phrases that must be hidden even if detection missed them (one per line).",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ] = None,
     mapping_in: Annotated[
         Optional[Path],
         typer.Option(
@@ -289,6 +314,13 @@ def run(
         )
         logging.info("  --operator after profile: %s", operator_map)
 
+    keep_phrases = load_phrase_list(str(keep_list)) if keep_list else None
+    deny_phrases = load_phrase_list(str(deny_list)) if deny_list else None
+    if keep_phrases:
+        logging.info("  --keep-list: %s phrase(s)", len(keep_phrases))
+    if deny_phrases:
+        logging.info("  --deny-list: %s phrase(s)", len(deny_phrases))
+
     logging.info(f"Found {len(file_paths)} file(s) to process.")
 
     seed_mapping = None
@@ -318,6 +350,8 @@ def run(
             operators=operator_map or None,
             fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
             seed_mapping=seed_mapping,
+            keep_list=keep_phrases,
+            deny_list=deny_phrases,
         )
 
         if full_anonymized_text and final_mapping:

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -116,6 +116,8 @@ VIN check digit, and a few national IDs). Failures are kept and labeled `TYPE_LI
 check are unchanged. Listing `IBAN` in a type filter also includes `IBAN_LIKE`.
 See `conf.py`, `regex_ner.py`, and `validators.py`.
 
+Pass `keep_list=` / `deny_list=` phrase lists into `anonymize_file` (CLI: `--keep-list` / `--deny-list`). Keep wins if a phrase is on both.
+
 Pass `seed_mapping=` (original → written) into `anonymize_file` so the same person stays `PERSON_1` across documents. The CLI `--mapping-in` flag loads that file (including encrypted maps).
 
 `EntityProfile.HIPAA_SAFE_HARBOR` is a coverage aid for Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). It is **not** a compliance certificate.

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.10.0"
+version = "0.11.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Tuple
 from pdf_anonymizer_core.call_llm import identify_entities_with_llm
 from pdf_anonymizer_core.conf import DEFAULT_CHUNK_OVERLAP, DEFAULT_REGEX_PATTERNS
 from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
+from pdf_anonymizer_core.gazetteers import apply_deny_list, apply_keep_list
 from pdf_anonymizer_core.operators import apply_operator, operator_for_type
 from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
 from pdf_anonymizer_core.utils import seed_placeholder_state
@@ -42,6 +43,8 @@ def anonymize_file(
     operators: Optional[Dict[str, str]] = None,
     fake_secret: Optional[str] = None,
     seed_mapping: Optional[Dict[str, str]] = None,
+    keep_list: Optional[List[str]] = None,
+    deny_list: Optional[List[str]] = None,
 ) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
     """Anonymize a file by processing its text content.
 
@@ -83,6 +86,8 @@ def anonymize_file(
             person + type + secret always yields the same fake.
         seed_mapping: Optional original → written map from a previous file so
             the same person keeps PERSON_1 (or the same fake) across documents.
+        keep_list: Phrases that must stay visible even if detected.
+        deny_list: Phrases that must be replaced even if detection missed them.
 
     Returns:
         A tuple (anonymized_text, mapping) where:
@@ -193,6 +198,7 @@ def anonymize_file(
         "ORGANIZATION": 2,
         "LOCATION": 1,
         "ADDRESS": 1,
+        "CUSTOM": 3,
     }
 
     def _type_priority(ent_type: str) -> int:
@@ -221,6 +227,11 @@ def anonymize_file(
             for e in deduped_entities
             if type_matches_filter(e["type"], anonymized_entities)
         ]
+
+    if deny_list:
+        entities_to_process = apply_deny_list(full_text, entities_to_process, deny_list)
+    if keep_list:
+        entities_to_process = apply_keep_list(entities_to_process, keep_list)
 
     logging.info(
         f"Collected {len(collected_entities)} total entities. "

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/gazetteers.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/gazetteers.py
@@ -1,0 +1,59 @@
+"""Keep-lists and deny-lists (gazetteers).
+
+Keep-list: never replace this phrase, even if regex or the model found it.
+Deny-list: always replace this phrase, even if both stages missed it.
+
+If a phrase is on both lists, keep wins (it stays visible).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+
+def load_phrase_list(path: str) -> List[str]:
+    """Load one phrase per line. Blank lines and # comments are ignored."""
+    phrases: List[str] = []
+    for raw in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        phrases.append(line)
+    return phrases
+
+
+def apply_keep_list(
+    entities: Sequence[Dict[str, str]], phrases: Iterable[str]
+) -> List[Dict[str, str]]:
+    """Drop entities whose text or base form is on the keep-list (case-insensitive)."""
+    skip = {phrase.lower() for phrase in phrases if phrase}
+    if not skip:
+        return list(entities)
+    kept: List[Dict[str, str]] = []
+    for entity in entities:
+        text = (entity.get("text") or "").lower()
+        base = (entity.get("base_form") or "").lower()
+        if text in skip or base in skip:
+            continue
+        kept.append(entity)
+    return kept
+
+
+def apply_deny_list(
+    text: str, entities: Sequence[Dict[str, str]], phrases: Iterable[str]
+) -> List[Dict[str, str]]:
+    """Add a CUSTOM entity for each deny-list phrase that appears in ``text``."""
+    extra: List[Dict[str, str]] = []
+    already = {(entity.get("text") or "").lower() for entity in entities}
+    for phrase in phrases:
+        if not phrase or phrase.lower() in already:
+            continue
+        match = re.search(re.escape(phrase), text, flags=re.IGNORECASE)
+        if not match:
+            continue
+        found = match.group(0)
+        extra.append({"text": found, "type": "CUSTOM", "base_form": found})
+        already.add(found.lower())
+    return list(entities) + extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_gazetteers.py
+++ b/tests/test_gazetteers.py
@@ -1,0 +1,74 @@
+"""Keep-list and deny-list gazetteers."""
+
+from pathlib import Path
+
+from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.gazetteers import (
+    apply_deny_list,
+    apply_keep_list,
+    load_phrase_list,
+)
+
+
+def test_load_phrase_list_skips_comments(tmp_path: Path) -> None:
+    path = tmp_path / "keep.txt"
+    path.write_text("# comment\nApple\n\nAcme Inc.\n", encoding="utf-8")
+    assert load_phrase_list(str(path)) == ["Apple", "Acme Inc."]
+
+
+def test_keep_list_drops_matching_entity() -> None:
+    entities = [
+        {"text": "Apple", "type": "ORGANIZATION", "base_form": "Apple"},
+        {"text": "Ada", "type": "PERSON", "base_form": "Ada"},
+    ]
+    kept = apply_keep_list(entities, ["apple"])
+    assert [e["text"] for e in kept] == ["Ada"]
+
+
+def test_deny_list_adds_missing_phrase() -> None:
+    text = "Please call the night desk at Acme."
+    entities = [{"text": "Ada", "type": "PERSON", "base_form": "Ada"}]
+    out = apply_deny_list(text, entities, ["acme"])
+    assert any(e["text"] == "Acme" and e["type"] == "CUSTOM" for e in out)
+
+
+def test_keep_wins_over_deny() -> None:
+    text = "Apple released a new phone."
+    entities = [{"text": "Apple", "type": "ORGANIZATION", "base_form": "Apple"}]
+    with_deny = apply_deny_list(text, entities, ["Apple"])
+    kept = apply_keep_list(with_deny, ["Apple"])
+    assert kept == []
+
+
+def test_anonymize_respects_keep_and_deny(mocker) -> None:
+    mocker.patch("os.path.getsize", return_value=0)
+    text = "Ada met Apple in Boston."
+    mocker.patch(
+        "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+        return_value=(text, [text]),
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.identify_entities_with_llm",
+        return_value=[
+            {"text": "Ada", "type": "PERSON", "base_form": "Ada"},
+            {"text": "Apple", "type": "ORGANIZATION", "base_form": "Apple"},
+        ],
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.extract_entities_via_regex",
+        return_value=[],
+    )
+    anonymized, mapping = anonymize_file(
+        "dummy.pdf",
+        1000,
+        "dummy",
+        "dummy",
+        keep_list=["Apple"],
+        deny_list=["Boston"],
+    )
+    assert "Ada" not in anonymized
+    assert "Apple" in anonymized
+    assert "Boston" not in anonymized
+    assert "PERSON_1" in anonymized
+    assert mapping.get("Boston") == "CUSTOM_1"
+    assert "Apple" not in mapping

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

A **keep-list** is phrases that must stay visible, even if the tool found them (your company name, or “Apple” the fruit).

A **deny-list** is phrases that must be hidden, even if regex and the model missed them.

One phrase per line. `#` starts a comment. If a phrase is on both lists, **keep wins**.

```bash
pdf-anonymizer run notes.pdf --keep-list keep.txt --deny-list must-hide.txt
```

Deny-list hits become `CUSTOM_1`, `CUSTOM_2`, and so on.

Packages: **0.10.0 → 0.11.0**.

## Docs

Recipes: “Keep some phrases, always hide others.” Also CLI usage and both package READMEs.

This is plan item 11 from `docs/internal/improvement-plan.md`.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (125 tests).