### PR TITLE
feat: replace entities by non-overlapping spans

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -17,7 +17,7 @@
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
 - [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, [PR #50](https://github.com/leo-gan/anonymizer/pull/50)
-- [x] 12. Span-based replacement — done 2026-08-15, `feat/span-replacement`
+- [x] 12. Span-based replacement — done 2026-08-15, [PR #51](https://github.com/leo-gan/anonymizer/pull/51)
 - [ ] 13. TAB-style eval harness
 - [ ] 14. OCR for scanned PDFs
 - [ ] 15. In-place PDF redaction
@@ -285,7 +285,7 @@ Known code facts to attach to:
 
 ### 12. Span-based replacement
 
-**Status:** done (2026-08-15) — `feat/span-replacement` (PR link after open)
+**Status:** done (2026-08-15) — [PR #51](https://github.com/leo-gan/anonymizer/pull/51) (`feat/span-replacement`)
 
 **Technique:** engineering. Makes operators and generalization more correct.  
 **Why:** Global string replace can change `May` inside the wrong word. Regex `finditer` offsets are thrown away today.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -17,7 +17,7 @@
 - [x] 9. Format-preserving synthetic replacements — done 2026-08-15, [PR #48](https://github.com/leo-gan/anonymizer/pull/48)
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
 - [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, [PR #50](https://github.com/leo-gan/anonymizer/pull/50)
-- [ ] 12. Span-based replacement
+- [x] 12. Span-based replacement — done 2026-08-15, `feat/span-replacement`
 - [ ] 13. TAB-style eval harness
 - [ ] 14. OCR for scanned PDFs
 - [ ] 15. In-place PDF redaction
@@ -284,6 +284,8 @@ Known code facts to attach to:
 ---
 
 ### 12. Span-based replacement
+
+**Status:** done (2026-08-15) — `feat/span-replacement` (PR link after open)
 
 **Technique:** engineering. Makes operators and generalization more correct.  
 **Why:** Global string replace can change `May` inside the wrong word. Regex `finditer` offsets are thrown away today.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -85,8 +85,10 @@ To solve coreference problems (e.g. associating "Dr. Smith", "Smith", and "Dr. J
 *   Standard placeholders are created using the entity type and an incremental count (e.g., `PERSON_1`, `PERSON_2`).
 *   **Variations Handling**: If an entity is a partial or varied reference of a base form (e.g. "John" vs. "John Doe"), a sub-variant placeholder is generated (e.g., `PERSON_1.v_1`). This tracks how the text refers to the individual without losing syntactic differences.
 
-### Replacing by Length Descending
-*   When masking the text, entities are replaced in descending order of string length. This prevents partial replacement bugs (e.g. replacing "John" in "John Doe" before trying to replace "John Doe").
+### Span-based replacement
+*   Mentions are located in the full document with word-boundary rules.
+*   Overlapping hits are resolved longest-first (`John Doe` wins over the inner `John`).
+*   Slices are written from the end of the string so earlier offsets stay valid.
 
 ---
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.11.0"
+version = "0.12.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.11.0"
+version = "0.12.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -15,7 +15,6 @@ and regex_ner docs for the full partitioned list).
 
 import logging
 import os
-import re
 import time
 from typing import Dict, List, Optional, Tuple
 
@@ -25,6 +24,7 @@ from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
 from pdf_anonymizer_core.gazetteers import apply_deny_list, apply_keep_list
 from pdf_anonymizer_core.operators import apply_operator, operator_for_type
 from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
+from pdf_anonymizer_core.spans import replace_entities
 from pdf_anonymizer_core.utils import seed_placeholder_state
 from pdf_anonymizer_core.validators import LIKE_SUFFIX, parent_type, type_matches_filter
 
@@ -326,20 +326,10 @@ def anonymize_file(
 
     anonymized_text = full_text
     if entities_to_process:
-        # Sort entities by length descending to match longer strings first
-        entities_to_process.sort(key=lambda e: len(e["text"]), reverse=True)
-
-        # Build selective boundary checks to prevent partial matching (e.g. "John" inside "Johnson")
-        def make_boundary_pattern(text: str) -> str:
-            prefix = r"\b" if text[0].isalnum() or text[0] == "_" else ""
-            suffix = r"\b" if text[-1].isalnum() or text[-1] == "_" else ""
-            return f"{prefix}{re.escape(text)}{suffix}"
-
-        pattern = re.compile(
-            "|".join(make_boundary_pattern(e["text"]) for e in entities_to_process)
-        )
-        anonymized_text = pattern.sub(
-            lambda m: final_mapping[m.group(0)], anonymized_text
+        anonymized_text = replace_entities(
+            full_text,
+            (entity["text"] for entity in entities_to_process),
+            final_mapping,
         )
 
     return anonymized_text, final_mapping

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/regex_ner.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/regex_ner.py
@@ -85,6 +85,7 @@ def extract_entities_via_regex(text: str, patterns: Dict[str, str]) -> List[Enti
         A list of EntityDict representing identified PII. "type" is always
         upper-cased. "base_form" currently equals the matched text (core
         consolidation may later promote variations to a longer base form).
+        Each hit also includes chunk-local ``start`` / ``end`` offsets.
     """
     entities: List[EntityDict] = []
 
@@ -115,6 +116,8 @@ def extract_entities_via_regex(text: str, patterns: Dict[str, str]) -> List[Enti
                         "text": matched_text,
                         "type": entity_type_upper,
                         "base_form": matched_text,
+                        "start": match.start(),
+                        "end": match.end(),
                     }
                 )
         except re.error as e:

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/spans.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/spans.py
@@ -1,0 +1,75 @@
+"""Locate and apply non-overlapping replacement intervals.
+
+Entity texts are found in the full document with the same word-boundary
+rules as before. Longer intervals win when two hits overlap, so
+``John Doe`` is replaced and the inner ``John`` is left alone.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+Span = Tuple[int, int, str]
+
+
+def make_boundary_pattern(text: str) -> str:
+    """Word-boundary wrap when the first/last character is alphanumeric."""
+    prefix = r"\b" if text[0].isalnum() or text[0] == "_" else ""
+    suffix = r"\b" if text[-1].isalnum() or text[-1] == "_" else ""
+    return f"{prefix}{re.escape(text)}{suffix}"
+
+
+def locate_spans(full_text: str, entity_texts: Iterable[str]) -> List[Span]:
+    """Find every bounded occurrence of each entity text in ``full_text``."""
+    spans: List[Span] = []
+    seen = set()
+    for text in entity_texts:
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        pattern = re.compile(make_boundary_pattern(text))
+        for match in pattern.finditer(full_text):
+            spans.append((match.start(), match.end(), text))
+    return spans
+
+
+def _overlaps(start: int, end: int, taken: Sequence[Tuple[int, int]]) -> bool:
+    for taken_start, taken_end in taken:
+        if not (end <= taken_start or start >= taken_end):
+            return True
+    return False
+
+
+def pick_non_overlapping(spans: Sequence[Span]) -> List[Span]:
+    """Keep longest spans first; drop any that overlap an accepted span."""
+    ordered = sorted(spans, key=lambda item: (item[1] - item[0], -item[0]), reverse=True)
+    accepted: List[Span] = []
+    taken: List[Tuple[int, int]] = []
+    for start, end, text in ordered:
+        if _overlaps(start, end, taken):
+            continue
+        accepted.append((start, end, text))
+        taken.append((start, end))
+    return accepted
+
+
+def apply_spans(full_text: str, spans: Sequence[Span], mapping: Dict[str, str]) -> str:
+    """Write replacements from the end of the string so earlier offsets stay valid."""
+    pieces = list(full_text)
+    # Walk right-to-left so later slices do not shift earlier indexes.
+    for start, end, text in sorted(spans, key=lambda item: item[0], reverse=True):
+        replacement = mapping.get(text)
+        if replacement is None:
+            continue
+        pieces[start:end] = list(replacement)
+    return "".join(pieces)
+
+
+def replace_entities(full_text: str, entity_texts: Iterable[str], mapping: Dict[str, str]) -> str:
+    """Locate, resolve overlaps, and replace. Empty entity list is a no-op."""
+    texts = [text for text in entity_texts if text]
+    if not texts:
+        return full_text
+    spans = pick_non_overlapping(locate_spans(full_text, texts))
+    return apply_spans(full_text, spans, mapping)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,0 +1,48 @@
+"""Span-based replacement: longest interval wins, no overlap."""
+
+from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.spans import (
+    apply_spans,
+    locate_spans,
+    pick_non_overlapping,
+    replace_entities,
+)
+
+
+def test_longer_span_wins_over_inner_name() -> None:
+    text = "John Doe met John."
+    spans = locate_spans(text, ["John Doe", "John"])
+    kept = pick_non_overlapping(spans)
+    mapping = {"John Doe": "PERSON_1", "John": "PERSON_1.v_1"}
+    out = apply_spans(text, kept, mapping)
+    assert out == "PERSON_1 met PERSON_1.v_1."
+
+
+def test_word_boundary_skips_partial() -> None:
+    text = "Johnson saw John."
+    out = replace_entities(text, ["John"], {"John": "PERSON_1"})
+    assert out == "Johnson saw PERSON_1."
+
+
+def test_anonymize_uses_spans(mocker) -> None:
+    mocker.patch("os.path.getsize", return_value=0)
+    text = "John Doe and John went to Johnson."
+    mocker.patch(
+        "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+        return_value=(text, [text]),
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.identify_entities_with_llm",
+        return_value=[
+            {"text": "John Doe", "type": "PERSON", "base_form": "John Doe"},
+            {"text": "John", "type": "PERSON", "base_form": "John Doe"},
+        ],
+    )
+    mocker.patch(
+        "pdf_anonymizer_core.core.extract_entities_via_regex",
+        return_value=[],
+    )
+    anonymized, _mapping = anonymize_file("dummy.pdf", 1000, "dummy", "dummy")
+    assert "John Doe" not in anonymized
+    assert "Johnson" in anonymized
+    assert anonymized.startswith("PERSON_1")

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Replacement is now interval-based. Mentions are found in the full document with word boundaries. If two hits overlap, the longer one wins (`John Doe` over the inner `John`). Slices are written from the end of the string.

Regex hits also store chunk-local `start` / `end`.

Packages: **0.11.0 → 0.12.0**.

This is plan item 12.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (128 tests).