### PR TITLE
feat: add TAB-style mention and entity eval harness

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -18,7 +18,7 @@
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
 - [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, [PR #50](https://github.com/leo-gan/anonymizer/pull/50)
 - [x] 12. Span-based replacement — done 2026-08-15, [PR #51](https://github.com/leo-gan/anonymizer/pull/51)
-- [ ] 13. TAB-style eval harness
+- [x] 13. TAB-style eval harness — done 2026-08-15, `feat/eval-harness`
 - [ ] 14. OCR for scanned PDFs
 - [ ] 15. In-place PDF redaction
 - [ ] 16. Regex-only / offline mode
@@ -39,24 +39,26 @@ This product is a **reversible document pseudonymizer**: typed placeholders (`PE
 
 | Technique (history.md) | Today |
 |---|---|
-| Data removal / identifier stripping | Hybrid RE2 + LLM NER, then global string replace |
-| Pseudonymization | Typed tokens + plaintext `data/mappings/*.json` |
-| Generalization / suppression | Not implemented |
+| Data removal / identifier stripping | Hybrid RE2 + LLM NER, then span-based replacement |
+| Pseudonymization | Typed tokens + `data/mappings/*.json` (optional AES-256-GCM) |
+| Generalization / suppression | Operators: `mask`, `hash`, `generalize`, `shift` (default still `replace`) |
 | Randomization / differential privacy | Not implemented (poor fit for reversible prose) |
 | *k*-anonymity / ℓ-diversity / *t*-closeness | Not implemented (tabular models; do not rewrite PDFs with them) |
-| Synthetic data | Not implemented |
-| Cryptographic methods | Mapping stored as plaintext |
-| Re-ID / attack simulation | Residual regex scan + linkage-risk report (`*.residual_pii.json`, `*.risk.json`) |
+| Synthetic data | Value-level `fake` operator (seeded Faker); not whole-document rewrite |
+| Cryptographic methods | Optional AES-256-GCM mapping (`*.mapping.json.enc`) |
+| Re-ID / attack simulation | Residual regex scan + linkage-risk report + TAB-style eval harness (`tests/eval/`) |
 
 Known code facts to attach to:
 
 - `conf.py`: regexes are still structural. After a match, `validators.py` runs a cheap check (Luhn, IBAN, VIN, a few national IDs). Failures stay hidden as `TYPE_LIKE` (`IBAN_LIKE_1`).
-- `core.py`: replacement is whole-document string match, not character spans.
+- `core.py`: replacement is span-based (locate in `full_text`, longest-first, write from the end). Shipped in [PR #51](https://github.com/leo-gan/anonymizer/pull/51).
 - `prompts/detailed.py`: asks for identity clues (`INDIRECT`, or `PERSON` with a known `base_form`) plus birthdates; `simple.py` does not. Shipped in [PR #40](https://github.com/leo-gan/anonymizer/pull/40).
 - Mapping files are plaintext by default. `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY` writes `*.mapping.json.enc` (AES-256-GCM).
-- `--operator TYPE=mask|hash|generalize|shift` changes how a type is written. Default remains `replace` (PERSON_1).
+- `--operator TYPE=mask|hash|generalize|shift|fake` changes how a type is written. Default remains `replace` (PERSON_1).
 - `--entity-profile hipaa-safe-harbor` is a coverage aid (year-only dates, ZIP3, age 90+). Not a compliance certificate.
 - National-ID regexes can be limited with `filter_regex_patterns(["US", "GB"])` or CLI `--countries US,GB`. Universal patterns always stay.
+- `--keep-list` / `--deny-list` gazetteers. Keep wins if a phrase is on both lists.
+- `tests/eval/` scores mention-level and entity-level recall, split by direct vs quasi identifiers. `scripts/eval_tab.py` runs the fixture (regex stage if no predictions file). No product behavior change.
 
 ---
 
@@ -301,6 +303,8 @@ Known code facts to attach to:
 ---
 
 ### 13. TAB-style eval harness
+
+**Status:** done (2026-08-15) — `feat/eval-harness` (PR link after open)
 
 **Technique:** the open question in history.md: how do you measure leftover risk and utility?  
 **Why:** Unit tests cover regex and mapping, not privacy metrics. No recall split for direct vs quasi identifiers.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -18,7 +18,7 @@
 - [x] 10. Cross-document consistent placeholders — done 2026-08-15, [PR #49](https://github.com/leo-gan/anonymizer/pull/49)
 - [x] 11. Allowlist / denylist gazetteers — done 2026-08-15, [PR #50](https://github.com/leo-gan/anonymizer/pull/50)
 - [x] 12. Span-based replacement — done 2026-08-15, [PR #51](https://github.com/leo-gan/anonymizer/pull/51)
-- [x] 13. TAB-style eval harness — done 2026-08-15, `feat/eval-harness`
+- [x] 13. TAB-style eval harness — done 2026-08-15, [PR #52](https://github.com/leo-gan/anonymizer/pull/52)
 - [ ] 14. OCR for scanned PDFs
 - [ ] 15. In-place PDF redaction
 - [ ] 16. Regex-only / offline mode
@@ -304,7 +304,7 @@ Known code facts to attach to:
 
 ### 13. TAB-style eval harness
 
-**Status:** done (2026-08-15) — `feat/eval-harness` (PR link after open)
+**Status:** done (2026-08-15) — [PR #52](https://github.com/leo-gan/anonymizer/pull/52) (`feat/eval-harness`)
 
 **Technique:** the open question in history.md: how do you measure leftover risk and utility?  
 **Why:** Unit tests cover regex and mapping, not privacy metrics. No recall split for direct vs quasi identifiers.

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.12.0"
+version = "0.13.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.12.0"
+version = "0.13.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/scripts/eval_tab.py
+++ b/scripts/eval_tab.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Score a system output against a TAB-style gold fixture.
+
+Usage:
+    uv run python scripts/eval_tab.py
+    uv run python scripts/eval_tab.py --fixture tests/eval/fixture.json --predictions pred.json
+
+If --predictions is omitted, the built-in regex stage is run on the fixture text.
+Prints JSON with mention-level and entity-level scores for all / direct / quasi.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+    sys.path.insert(0, str(ROOT / "packages" / "pdf-anonymizer-core" / "src"))
+
+from tests.eval.metrics import evaluate_fixture  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture",
+        default=str(ROOT / "tests" / "eval" / "fixture.json"),
+        help="Gold JSON with text + mentions",
+    )
+    parser.add_argument(
+        "--predictions",
+        default=None,
+        help="JSON list of predicted mentions, or omit to run regex NER",
+    )
+    args = parser.parse_args()
+
+    fixture = json.loads(Path(args.fixture).read_text(encoding="utf-8"))
+    if args.predictions:
+        predicted = json.loads(Path(args.predictions).read_text(encoding="utf-8"))
+    else:
+        from pdf_anonymizer_core.conf import DEFAULT_REGEX_PATTERNS
+        from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
+
+        ents = extract_entities_via_regex(fixture["text"], DEFAULT_REGEX_PATTERNS)
+        predicted = [
+            {
+                "text": ent["text"],
+                "type": ent["type"],
+                "start": ent.get("start"),
+                "end": ent.get("end"),
+            }
+            for ent in ents
+        ]
+
+    report = evaluate_fixture(fixture, predicted)
+    json.dump(report, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""TAB-style evaluation helpers (tests and scripts only)."""

--- a/tests/eval/fixture.json
+++ b/tests/eval/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "mini-tab",
+  "text": "Ada Lovelace (ada@example.com) lives in London. SSN 000-00-0000. Born 1815-12-10.",
+  "mentions": [
+    {"text": "Ada Lovelace", "type": "PERSON", "kind": "direct", "start": 0, "end": 12, "base_form": "Ada Lovelace"},
+    {"text": "ada@example.com", "type": "EMAIL", "kind": "direct", "start": 14, "end": 29, "base_form": "ada@example.com"},
+    {"text": "London", "type": "LOCATION", "kind": "quasi", "start": 40, "end": 46, "base_form": "London"},
+    {"text": "000-00-0000", "type": "SSN", "kind": "direct", "start": 52, "end": 63, "base_form": "000-00-0000"},
+    {"text": "1815-12-10", "type": "DATE_ISO", "kind": "quasi", "start": 70, "end": 80, "base_form": "1815-12-10"}
+  ]
+}

--- a/tests/eval/metrics.py
+++ b/tests/eval/metrics.py
@@ -1,0 +1,133 @@
+"""Mention-level and entity-level scores, split by direct vs quasi identifiers.
+
+TAB (Pilán et al., 2022) reports these separately because quasi-identifiers
+are common and can hide a poor score on names and emails.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Set, Tuple
+
+DIRECT_TYPES = frozenset(
+    {
+        "PERSON",
+        "EMAIL",
+        "PHONE",
+        "FAX",
+        "SSN",
+        "SSN_US",
+        "CREDIT_CARD",
+        "CREDIT_CARD_LIKE",
+        "IBAN",
+        "IBAN_LIKE",
+        "ID",
+        "ACCOUNT",
+        "MEDICAL_RECORD",
+        "HEALTH_PLAN_ID",
+    }
+)
+QUASI_TYPES = frozenset(
+    {
+        "LOCATION",
+        "ADDRESS",
+        "DATE",
+        "DATE_ISO",
+        "ORGANIZATION",
+        "JOB_TITLE",
+        "AGE",
+        "INDIRECT",
+    }
+)
+
+
+def mention_key(mention: Dict[str, Any]) -> Tuple[Any, ...]:
+    """Prefer exact offsets; fall back to lowercase text."""
+    start, end = mention.get("start"), mention.get("end")
+    text = str(mention.get("text", "")).strip().lower()
+    if isinstance(start, int) and isinstance(end, int):
+        return ("span", start, end, text)
+    return ("text", text)
+
+
+def entity_key(mention: Dict[str, Any]) -> Tuple[str, str]:
+    kind = mention_kind(mention)
+    base = str(mention.get("base_form") or mention.get("text") or "").strip().lower()
+    return (kind, base)
+
+
+def mention_kind(mention: Dict[str, Any]) -> str:
+    if mention.get("kind") in {"direct", "quasi"}:
+        return str(mention["kind"])
+    typ = str(mention.get("type", "")).upper()
+    if typ in DIRECT_TYPES or typ.startswith("SSN"):
+        return "direct"
+    if typ in QUASI_TYPES:
+        return "quasi"
+    return "other"
+
+
+def _prf(true_pos: int, pred_n: int, gold_n: int) -> Dict[str, float]:
+    precision = true_pos / pred_n if pred_n else 0.0
+    recall = true_pos / gold_n if gold_n else 0.0
+    if precision + recall == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "true_positives": true_pos,
+        "predicted": pred_n,
+        "gold": gold_n,
+    }
+
+
+def mention_scores(
+    gold: Iterable[Dict[str, Any]], predicted: Iterable[Dict[str, Any]]
+) -> Dict[str, float]:
+    gold_keys = [mention_key(item) for item in gold]
+    pred_keys = [mention_key(item) for item in predicted]
+    gold_set: Set[Tuple[Any, ...]] = set(gold_keys)
+    matched = 0
+    used: Set[Tuple[Any, ...]] = set()
+    for key in pred_keys:
+        if key in gold_set and key not in used:
+            matched += 1
+            used.add(key)
+    return _prf(matched, len(pred_keys), len(gold_keys))
+
+
+def entity_recall(
+    gold: Iterable[Dict[str, Any]], predicted: Iterable[Dict[str, Any]]
+) -> Dict[str, float]:
+    gold_entities = {entity_key(item) for item in gold}
+    pred_entities = {entity_key(item) for item in predicted}
+    hit = len(gold_entities & pred_entities)
+    return _prf(hit, len(pred_entities), len(gold_entities))
+
+
+def scores_by_kind(
+    gold: List[Dict[str, Any]], predicted: List[Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
+    report: Dict[str, Dict[str, Any]] = {"all": {}}
+    report["all"]["mention"] = mention_scores(gold, predicted)
+    report["all"]["entity"] = entity_recall(gold, predicted)
+    for kind in ("direct", "quasi"):
+        gold_k = [item for item in gold if mention_kind(item) == kind]
+        pred_k = [item for item in predicted if mention_kind(item) == kind]
+        report[kind] = {
+            "mention": mention_scores(gold_k, pred_k),
+            "entity": entity_recall(gold_k, pred_k),
+        }
+    return report
+
+
+def evaluate_fixture(
+    fixture: Dict[str, Any], predicted: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    gold = list(fixture.get("mentions") or [])
+    return {
+        "name": fixture.get("name", "fixture"),
+        "scores": scores_by_kind(gold, predicted),
+    }

--- a/tests/eval/test_metrics.py
+++ b/tests/eval/test_metrics.py
@@ -1,0 +1,49 @@
+"""TAB-style scores on the mini fixture."""
+
+import json
+from pathlib import Path
+
+from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
+from pdf_anonymizer_core.conf import DEFAULT_REGEX_PATTERNS
+
+from tests.eval.metrics import entity_recall, evaluate_fixture, mention_scores
+
+FIXTURE_PATH = Path(__file__).with_name("fixture.json")
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_perfect_predictions_score_one() -> None:
+    fixture = _load_fixture()
+    gold = fixture["mentions"]
+    mention = mention_scores(gold, gold)
+    entity = entity_recall(gold, gold)
+    assert mention["recall"] == 1.0
+    assert mention["precision"] == 1.0
+    assert entity["recall"] == 1.0
+
+
+def test_missing_direct_id_lowers_direct_recall() -> None:
+    fixture = _load_fixture()
+    gold = fixture["mentions"]
+    predicted = [m for m in gold if m["type"] != "EMAIL"]
+    report = evaluate_fixture(fixture, predicted)
+    assert report["scores"]["direct"]["mention"]["recall"] < 1.0
+    assert report["scores"]["quasi"]["mention"]["recall"] == 1.0
+
+
+def test_regex_stage_on_fixture_finds_structured_direct() -> None:
+    fixture = _load_fixture()
+    ents = extract_entities_via_regex(fixture["text"], DEFAULT_REGEX_PATTERNS)
+    predicted = [
+        {"text": e["text"], "type": e["type"], "start": e.get("start"), "end": e.get("end")}
+        for e in ents
+    ]
+    report = evaluate_fixture(fixture, predicted)
+    # Regex should catch email (and likely the ISO date). Names need the LLM.
+    assert report["scores"]["direct"]["mention"]["recall"] > 0
+    email_gold = [m for m in fixture["mentions"] if m["type"] == "EMAIL"]
+    email_pred = [p for p in predicted if p["type"] == "EMAIL"]
+    assert mention_scores(email_gold, email_pred)["recall"] == 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds a small TAB-style eval harness (tests and scripts only — no product change).

- `tests/eval/metrics.py` scores mention-level and entity-level precision / recall / F1
- Split by **direct** identifiers (EMAIL, SSN, PERSON, …) vs **quasi** (LOCATION, DATE, …)
- Mini gold fixture in `tests/eval/fixture.json`
- `scripts/eval_tab.py` prints JSON; omit `--predictions` to run the regex stage on the fixture

Packages: **0.12.0 → 0.13.0**.

This is plan item 13.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (131 tests).