### PR TITLE
docs: sync public pages with shipped plan items 1–13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ print(anonymize_file('data/sample.pdf', 50000, detailed.prompt_template, 'gemini
 - Source lives in `docs/`.
 - The site is built with MkDocs + Material.
 - New practical examples go in `docs/project/recipes.md`.
+- New CLI flags also belong on the [CLI History](docs/project/cli-usage.md#history) list.
+- Privacy-metric experiments go in `tests/eval/` (see `scripts/eval_tab.py`).
 - Hand-written usage guidance lives in `docs/project/`.
 - Auto-generated reference (via mkdocstrings) is at `docs/project/api-reference.md`.
 - Please keep docstrings in the Python source reasonably complete — they feed the API reference.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This application anonymizes large PDF, Markdown, or Text files using a **hybrid 
 
 - **High-Quality Anonymization**: Leverages LLMs to identify and replace Personally Identifiable Information (PII) with high accuracy.
 - **Identity clues, not only names**: A sentence can point to one person without writing their name ("the CEO of Tesla", "the author of the 'Harry Potter' series"). The careful (`detailed`) instructions ask the language model to hide those phrases too. Use `-p best-quality` or `--prompt-name detailed`. The fast default does not. Plain-language explanation: [Identity clues](https://leo-gan.github.io/anonymizer/101/how-different/#identity-clues-when-the-name-is-missing-but-everyone-still-knows-who-it-is).
-- **Fast & Safe Regex Pre-Filter (Hybrid NER)**: First stage uses the RE2 engine (`google-re2`) for linear-time, ReDoS-safe detection of 70+ structured PII patterns (emails, phones, URLs, credit cards, IBANs, crypto wallets, VINs, MACs, dates, currency, plus national IDs/tax IDs/driver licenses/VAT/business/government IDs etc.). Country-partitioned patterns cover 30+ jurisdictions (mandatory: USA, Canada, UK, Spain, Italy, France, India, China + DE, JP, BR, AU, NL, and many more). After a match, cheap checksums (the same kind of “did you type this number wrong?” check a shop uses on a card) decide the label: a real IBAN becomes `IBAN_1`, a mistyped one becomes `IBAN_LIKE_1`. The number is still hidden either way. Regex results are priority-merged with the LLM stage. Full list and per-country details are in the core package docs and recipes.
+- **Fast & Safe Regex Pre-Filter (Hybrid NER)**: First stage uses the RE2 engine (`google-re2`) for linear-time, ReDoS-safe detection of 70+ structured PII patterns (emails, phones, URLs, credit cards, IBANs, crypto wallets, VINs, MACs, dates, currency, plus national IDs/tax IDs/driver licenses/VAT/business/government IDs etc.). Country-partitioned patterns cover 30+ jurisdictions (mandatory: USA, Canada, UK, Spain, Italy, France, India, China + DE, JP, BR, AU, NL, and many more). After a match, cheap checksums (the same kind of “did you type this number wrong?” check a shop uses on a card) decide the label: a real IBAN becomes `IBAN_1`, a mistyped one becomes `IBAN_LIKE_1`. The number is still hidden either way. Limit national IDs with `--countries US,GB`. Regex results are priority-merged with the LLM stage. Full list and per-country details are in the core package docs and recipes.
+- **How a type is written**: Default is a reversible stand-in (`PERSON_1`). `--operator CREDIT_CARD=mask` (or `hash` / `generalize` / `shift` / `fake`) changes that type. `--entity-profile hipaa-safe-harbor` is a coverage aid (year-only dates, ZIP3, age 90+), **not** a certificate.
+- **After masking**: `run` writes `*.residual_pii.json` (leftovers) and `*.risk.json` (identity-clue clumps). `pdf-anonymizer verify` and `pdf-anonymizer report` do the same later. Reports do not rewrite the page.
+- **Same person, same stand-in**: Files in one `run` share a growing map. `--mapping-in` continues a later batch. `--keep-list` / `--deny-list` leave phrases visible or force-hide them. Maps can be locked as `*.mapping.json.enc`.
 - **Large File Support**: Consistently anonymizes large files (tested up to 1GB).
 - **Multi-Provider & Cost-Effective**: Free to use with local [Ollama](https://ollama.com/) models. It also supports major providers like [OpenAI](https://openai.com/), [Anthropic](https://www.anthropic.com/), [Google](https://ai.google.com/), [Hugging Face](https://huggingface.co/), and [OpenRouter](https://openrouter.ai/).
 - **Reversible**: Supports deanonymization to recover original data when needed.
@@ -20,7 +23,7 @@ A comprehensive documentation site is available at **[leo-gan.github.io/anonymiz
 The documentation includes:
 - **[Anonymization 101](https://leo-gan.github.io/anonymizer/101/)**: A guide on data anonymization and deanonymization techniques.
 - **[Installation Guide](https://leo-gan.github.io/anonymizer/project/installation/)**: System requirements, package extras, and setup.
-- **[CLI Usage](https://leo-gan.github.io/anonymizer/project/cli-usage/)**: Reference manual for `pdf-anonymizer run` and `pdf-anonymizer deanonymize` (including configuration profiles).
+- **[CLI Usage](https://leo-gan.github.io/anonymizer/project/cli-usage/)**: Reference for `run`, `verify`, `report`, and `deanonymize`, plus a [History](https://leo-gan.github.io/anonymizer/project/cli-usage/#history) of what landed.
 - **[API Usage](https://leo-gan.github.io/anonymizer/project/api-usage/)**: Programmatic usage guide for the core SDK.
 - **[API Reference (auto)](https://leo-gan.github.io/anonymizer/project/api-reference/)**: Auto-generated function signatures and details.
 - **[Recipes & Common Workflows](https://leo-gan.github.io/anonymizer/project/recipes/)**: Practical patterns (local Ollama, external LLM round-trips, batching, profiles, caching, debugging, etc.).
@@ -67,6 +70,10 @@ This project is a monorepo containing two main packages:
 
     # For OpenRouter models
     OPENROUTER_API_KEY="YOUR_OPENROUTER_KEY"
+
+    # Optional: lock mapping files / seed fake names
+    ANONYMIZER_MAPPING_KEY="a long secret"
+    ANONYMIZER_FAKE_SECRET="another long secret"
     ```
 
 ## Quick Start

--- a/docs/101/history.md
+++ b/docs/101/history.md
@@ -80,6 +80,22 @@ Researchers have developed many techniques to protect privacy. Major methods inc
 
 *Table: Comparison of anonymization techniques (strengths, weaknesses, typical uses).*
 
+### How this project uses these ideas (today)
+
+This page is a history lesson, not a product spec. The tool you can run (`pdf-anonymizer`) is a **reversible document pseudonymizer**. It hides words in a PDF, Markdown, or text file and keeps a separate map so you can put them back. It is **not** a *k*-anonymity rewriter and it does **not** add differential-privacy noise to prose.
+
+| Idea on this page | What the tool does today |
+|---|---|
+| Data removal (strip names, SSNs) | Hybrid RE2 regex + LLM, then span-based replacement. Mistyped IBANs become `IBAN_LIKE_1`, not leftover digits. |
+| Pseudonymization | Typed stand-ins (`PERSON_1`) plus `*.mapping.json`. Optional AES-256-GCM lock (`*.mapping.json.enc`). |
+| Generalization / suppression | Optional operators: year-only dates, ZIP3, age bands, masks, hashes. Default is still `PERSON_1`. |
+| Synthetic data | Value-level `fake` operator (same person → same invented name). Not a whole-document rewrite. |
+| Cryptographic methods | Optional encrypted mapping file. Not homomorphic encryption. |
+| Re-ID / attack simulation | Leftover regex scan (`*.residual_pii.json`), linkage-risk score (`*.risk.json`), and a TAB-style eval harness in `tests/eval/`. |
+| *k*-anonymity / DP / mixnets | Out of scope as document rewriters. Those models are for tables or networks, not narrative PDFs. |
+
+A flag-by-flag list lives on the [CLI History](../project/cli-usage.md#history) page. Worked examples live in [Recipes](../project/recipes.md).
+
 ## Legal, Regulatory and Policy Developments  
 - **OECD Guidelines (1980) & Fair Information Practices:** Early principles for data handling (collection limitation, purpose, security). Though not explicit on anonymization, they set the stage for later laws.  
 - **US Privacy Act (1974):** First U.S. federal law restricting personal data disclosure, requiring agencies to de-identify published records.  
@@ -176,4 +192,4 @@ timeline
 ---
 
 **In this course:**  
-[← Previous: Why Anonymize?](why-anonymization.md) | [Course Overview](index.md) | [Next: Where is it Needed?](where-needed.md)
+[← Previous: Why Anonymize?](why-anonymization.md) | [Course Overview](index.md) | [Next: Contemporary Techniques](techniques.md)

--- a/docs/101/how-different.md
+++ b/docs/101/how-different.md
@@ -60,6 +60,10 @@ pdf-anonymizer run notes.pdf --prompt-name detailed
 
 This is still a helper, not a guarantee. A very unusual clue can be missed. If a document must be safe to share, a person should still read the result.
 
+After `run`, two report files help you look: `*.residual_pii.json` (leftover emails or numbers) and `*.risk.json` (identity-clue clumps such as job + company + place). They do **not** rewrite the page.
+
+A flag-by-flag list of what landed is on the [CLI History](../project/cli-usage.md#history) page.
+
 ---
 
 ## Reversible Masking (The Mapping Engine)
@@ -68,8 +72,8 @@ Many tools simply erase text or replace it with generic masks (like `<REDACTED>`
 
 PDF Anonymizer creates **reversible placeholder mappings**:
 
-- **Placeholders retain context**: Instead of generic redaction, identifiers are replaced with typed, incremented placeholders (e.g., `[PERSON_1]`, `[COMPANY_2]`, `[DATE_1]`). This preserves the grammar, flow, and structural meaning of the document.
-- **Separate Cryptographic Map**: The CLI outputs an anonymized document along with a JSON-formatted mapping file (e.g., `document.mapping.json`).
+- **Placeholders retain context**: Instead of generic redaction, identifiers are replaced with typed, incremented placeholders (e.g., `PERSON_1`, `ORGANIZATION_2`, `DATE_1`). This preserves the grammar, flow, and structural meaning of the document.
+- **Separate mapping file**: The CLI outputs an anonymized document along with a JSON mapping file (e.g., `document.mapping.json`). You can lock that file as `*.mapping.json.enc` (AES-256-GCM) with a passphrase. Default is still plaintext JSON.
 - **Local Deanonymization**: You can send the anonymized document to a third party or public AI service for processing, translation, or analysis. When the results return, you run the CLI's `deanonymize` command locally with the mapping file to restore the original names.
 
 ```
@@ -114,8 +118,11 @@ Large documents (like a 500-page clinical trial registry or a 1GB database expor
 
 | Feature | Legacy Regex/NER Tools | Generic Cloud Redactors | PDF Anonymizer |
 | :--- | :--- | :--- | :--- |
-| **Contextual PII detection** | :x: No (Regex/Static) | :wavy_dash: Limited | :white_check_mark: Yes (LLM semantic comprehension) |
-| **Reversibility** | :x: No | :x: No | :white_check_mark: Yes (Separate JSON maps) |
+| **Contextual PII detection** | :x: No (Regex/Static) | :wavy_dash: Limited | :white_check_mark: Yes (LLM + identity clues) |
+| **Mistyped numbers** | Often left in the clear | Varies | :white_check_mark: Hidden as `IBAN_LIKE_1` |
+| **Reversibility** | :x: No | :x: No | :white_check_mark: Yes (JSON map; optional lock) |
+| **How a type is written** | Usually one mask | Usually one mask | :white_check_mark: `replace` / `mask` / `hash` / `generalize` / `shift` / `fake` |
+| **Leftover / linkage check** | Rare | Rare | :white_check_mark: Report files only (no auto-rewrite) |
 | **Local Offline Run** | :white_check_mark: Yes | :x: No (Cloud only) | :white_check_mark: Yes (Via local Ollama models) |
 | **Large File Support** | :wavy_dash: High memory usage | :x: Limited by file size limits | :white_check_mark: Yes (Streaming chunks up to 1GB) |
 | **Monorepo Architecture** | :wavy_dash: Often monolithic | :x: Closed source | :white_check_mark: Yes (Separated Core SDK and CLI) |

--- a/docs/101/index.md
+++ b/docs/101/index.md
@@ -29,8 +29,10 @@ Explore the modules below to build a strong foundation in data privacy:
 ### [How PDF Anonymizer is Different](how-different.md)
 *   **Limitations of Legacy Systems**: Why traditional systems fail on complex, unstructured text.
 *   **Identity clues**: Why hiding names is not enough, and how the careful instructions hide phrases like "the CEO of Tesla".
-*   **Reversible Workflows**: The power of cryptographic entity mapping.
+*   **Reversible Workflows**: Typed stand-ins plus a separate mapping file (optional lock).
 *   **Local Execution**: Combining Ollama with local weights to prevent data from ever leaving your device.
+
+A flag-by-flag list of what the tool can do today is on the [CLI History](../project/cli-usage.md#history) page.
 
 ---
 

--- a/docs/101/techniques.md
+++ b/docs/101/techniques.md
@@ -98,5 +98,9 @@ A popular Python framework for detecting and redacting PII in unstructured text.
 
 ---
 
+**In this project.** PDF Anonymizer is the last row of that table (LLM-based masking with a map). You can also ask it to *mask*, *hash*, *generalize*, or invent a stable *fake* value for a type. It does **not** rewrite a PDF as a *k*-anonymous table or add differential-privacy noise to sentences. How those history-chapter ideas map onto flags is on the [History](history.md#how-this-project-uses-these-ideas-today) page and the [CLI History](../project/cli-usage.md#history).
+
+---
+
 **In this course:**  
 [← Previous: History](history.md) | [Course Overview](index.md) | [Next: How PDF Anonymizer is Different](how-different.md)

--- a/docs/101/why-anonymization.md
+++ b/docs/101/why-anonymization.md
@@ -24,7 +24,7 @@ graph TD
 
 ### Reversible vs. Irreversible Anonymization
 *   **Irreversible Anonymization (Redaction)**: The original values are permanently destroyed. It is highly secure, but it limits downstream utility when you need to follow up or link records back to the source.
-*   **Reversible Anonymization (Masking & Mapping)**: Original PII is replaced with placeholders (e.g., `[PERSON_1]`, `[DATE_2]`), and a secure, encrypted mapping table is stored separately. The masked data can be sent to external entities (like AI models or third-party analysts), and the results can be mapped back to the individuals internally. This is the paradigm used by **PDF Anonymizer**.
+*   **Reversible Anonymization (Masking & Mapping)**: Original PII is replaced with placeholders (e.g., `PERSON_1`, `DATE_2`), and a mapping table is stored separately (plaintext JSON by default; you can lock it as `*.mapping.json.enc`). The masked data can be sent to external entities (like AI models or third-party analysts), and the results can be mapped back to the individuals internally. This is the paradigm used by **PDF Anonymizer**. It is GDPR *pseudonymization* while you still hold the map, not irreversible anonymization.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,9 @@ PDF Anonymizer is a high-performance, developer-friendly utility and Python SDK 
 
 ## Key Highlights
 
-*   **Context-Aware Accuracy**: Traditional systems rely on regex or fixed lists (NER), missing complex references. PDF Anonymizer uses LLMs to grasp the deep semantics and context of your documents.
-*   **100% Reversible**: Generate secure, deanonymizable files. Perfect for downstream workflows (like AI agents or translation) that require masking but must ultimately map back to original data.
+*   **Context-Aware Accuracy**: A fast RE2 regex stage (with checksums so mistyped IBANs become `IBAN_LIKE_1`, not leftover digits) plus an LLM that can hide identity clues, not only names.
+*   **Reversible by default**: Typed stand-ins (`PERSON_1`) plus a JSON mapping file. You can lock the map (`*.mapping.json.enc`), or write a type as a mask, a year, a hash, or a stable fake name instead.
+*   **Checks after masking**: A leftover scan (`*.residual_pii.json`) and a linkage-risk score (`*.risk.json`). Reports only — they do not rewrite the page.
 *   **Privacy First & Cost Effective**: Fully compatible with local, offline models using **Ollama** (e.g., Gemma 2, Phi 3/4). Also supports **Google Gemini**, **Anthropic Claude**, **OpenAI GPT**, **Hugging Face**, and **OpenRouter**.
 *   **Built for Scale**: Implements an intelligent stream-based chunking mechanism designed to reliably handle files up to **1GB** without running out of context windows or memory.
 
@@ -59,7 +60,9 @@ To deanonymize the file later:
 
 ```bash
 # Revert the anonymization
-pdf-anonymizer deanonymize data/sample.anonymized.md data/sample.mapping.json
+pdf-anonymizer deanonymize \
+  data/anonymized/sample.anonymized.md \
+  data/mappings/sample.mapping.json
 ```
 
 ---
@@ -78,4 +81,4 @@ We provide a pre-built example containing hybrid NER (Regex + LLM) and full roun
    uv run python scripts/demo_anonymize.py
    ```
 
-For many more real-world usage patterns (local-only processing, safe external LLM/agent workflows, batch jobs, entity-type filtering, profile selection, cache control, large documents, troubleshooting, etc.) see the dedicated **[Recipes & Common Workflows](project/recipes.md)** and **[Troubleshooting](project/troubleshooting.md)** pages. An auto-generated **[API Reference](project/api-reference.md)** is also available.
+For many more real-world usage patterns (local-only processing, locked maps, operators, HIPAA coverage aid, keep/deny lists, leftover checks, batch jobs, eval harness, troubleshooting, etc.) see the dedicated **[Recipes & Common Workflows](project/recipes.md)** and **[Troubleshooting](project/troubleshooting.md)** pages. An auto-generated **[API Reference](project/api-reference.md)** is also available. The CLI **[History](project/cli-usage.md#history)** lists what landed, flag by flag.

--- a/docs/project/api-reference.md
+++ b/docs/project/api-reference.md
@@ -35,6 +35,28 @@ The package ships two ready-to-use prompt templates.
 
 ::: pdf_anonymizer_core.prompts.simple
 
+::: pdf_anonymizer_core.prompts.hipaa
+
+---
+
+## Detection, operators, and reports
+
+::: pdf_anonymizer_core.regex_ner
+
+::: pdf_anonymizer_core.validators
+
+::: pdf_anonymizer_core.operators
+
+::: pdf_anonymizer_core.spans
+
+::: pdf_anonymizer_core.gazetteers
+
+::: pdf_anonymizer_core.verify
+
+::: pdf_anonymizer_core.risk
+
+::: pdf_anonymizer_core.mapping_crypto
+
 ---
 
 ## Low-Level Components (for advanced use / extension)
@@ -44,5 +66,3 @@ The package ships two ready-to-use prompt templates.
 ::: pdf_anonymizer_core.call_llm
 
 ::: pdf_anonymizer_core.load_and_extract
-
-::: pdf_anonymizer_core.regex_ner

--- a/docs/project/api-usage.md
+++ b/docs/project/api-usage.md
@@ -15,12 +15,19 @@ from pdf_anonymizer_core.core import anonymize_file
 
 ### Parameters
 *   `file_path` (`str`): The absolute or relative path to the input document (supports `.pdf`, `.md`, `.txt`).
+*   `characters_to_anonymize` (`int`): Target character size of each chunk sent to the LLM.
 *   `prompt_template` (`str`): The prompt template string containing instructions for entity masking.
 *   `model_name` (`str`): The target model name (e.g. `"gemini-2.5-flash"`, `"google/gemini-2.5-pro"`, `"ollama/phi4-mini"`).
+*   `anonymized_entities` (`list[str]`, optional): Type filter (e.g. `["PERSON", "ORGANIZATION"]`). Listing `IBAN` also includes `IBAN_LIKE`.
+*   `regex_patterns` (`dict`, optional): First-stage RE2 map. Defaults to `DEFAULT_REGEX_PATTERNS`. Use `filter_regex_patterns(["US", "GB"])` to keep only some national IDs.
+*   `operators` (`dict[str, str]`, optional): Type → `replace` / `mask` / `hash` / `generalize` / `shift` / `fake`. Unlisted types stay `replace`.
+*   `fake_secret` (`str`, optional): Seed for `fake`. Same person + type + secret → same fake.
+*   `seed_mapping` (`dict[str, str]`, optional): Original → written map from a previous file so Ada stays `PERSON_1`.
+*   `keep_list` / `deny_list` (`list[str]`, optional): Phrases to leave visible, or to force-hide as `CUSTOM_n`. Keep wins if both lists contain the same phrase.
 
 ### Returns
 *   `anonymized_text` (`str`): The fully processed text with placeholders in place of PII.
-*   `mapping` (`dict[str, str]`): A dictionary mapping original entities to their assigned placeholders.
+*   `mapping` (`dict[str, str]`): A dictionary mapping original entities to their assigned placeholders (or other written form).
 
 ---
 
@@ -35,7 +42,8 @@ from pdf_anonymizer_core.utils import deanonymize_file
 
 ### Parameters
 *   `anonymized_file_path` (`str`): Path to the markdown or text file that has placeholders.
-*   `mapping_file_path` (`str`): Path to the JSON mapping file containing the original entity-to-placeholder mapping dictionary.
+*   `mapping_file_path` (`str`): Path to the JSON mapping file (plaintext or `*.mapping.json.enc`).
+*   `mapping_passphrase` (`str`, optional): Required when the mapping file is encrypted. Also used by the CLI via `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY`.
 
 ### Returns
 *   `deanonymized_file_path` (`str`): Path to the written restored document.
@@ -64,12 +72,14 @@ print("Google models:", google_models)
 ```
 
 ### Selecting a Prompt Template
-The package provides two pre-configured prompt styles: `simple` and `detailed`.
+The package provides three pre-configured prompt styles: `simple`, `detailed`, and `hipaa`.
 
 `detailed` is the careful one. Besides names, emails, and similar labels, it asks the model to hide **identity clues**: phrases that point to one person without writing their name (for example "the CEO of Tesla", or "Acme Inc.'s only in-house patent counsel"). Those phrases come back as type `PERSON` (when the model knows the name) or type `INDIRECT` (when it does not). `simple` does not ask for this, so it stays cheaper.
 
+`hipaa` is the coverage aid used by `--entity-profile hipaa-safe-harbor`. It is **not** a compliance certificate.
+
 ```python
-from pdf_anonymizer_core.prompts import simple, detailed
+from pdf_anonymizer_core.prompts import simple, detailed, hipaa
 
 # Use the detailed prompt template (recommended when identity clues matter)
 prompt_text = detailed.prompt_template
@@ -97,8 +107,9 @@ model = "gemini-2.5-flash"
 print(f"Anonymizing {input_document} using {model}...")
 anonymized_text, mapping = anonymize_file(
     file_path=input_document,
+    characters_to_anonymize=30000,
     prompt_template=detailed.prompt_template,
-    model_name=model
+    model_name=model,
 )
 
 # 2. Inspect the outputs
@@ -146,7 +157,17 @@ from pdf_anonymizer_core.llm_provider import configure_cache
 configure_cache(enabled=True, cache_dir="my-cache", cache_file="responses.json")
 ```
 
-For the complete `anonymize_file` signature (including `chunk_overlap`, `regex_patterns`, `max_retries`, etc.) see the [auto-generated API Reference](api-reference.md) or the Recipes page.
+Related helpers (report only, they do not rewrite text):
+
+```python
+from pdf_anonymizer_core.verify import verify_anonymized_text, write_residual_report
+from pdf_anonymizer_core.risk import assess_linkage_risk, write_risk_report
+
+write_residual_report(verify_anonymized_text(anonymized_text), anonymized_path)
+write_risk_report(assess_linkage_risk(anonymized_text), anonymized_path)
+```
+
+For the complete `anonymize_file` signature (including `chunk_overlap`, `regex_patterns`, `max_retries`, `operators`, `seed_mapping`, gazetteers, etc.) see the [auto-generated API Reference](api-reference.md) or the Recipes page.
 
 ---
 
@@ -158,4 +179,3 @@ For the complete `anonymize_file` signature (including `chunk_overlap`, `regex_p
 - **[Architecture Design](architecture.md)** — internals behind the functions documented here.
 - **[Installation & Setup](installation.md)** — how to set up the environment for the SDK.
 - **[Troubleshooting](troubleshooting.md)** — help with common SDK and CLI issues.
-- **[Architecture Design](architecture.md)** — how the anonymization pipeline, consolidation, and deanonymization actually work internally.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -40,12 +40,18 @@ graph TD
     File[Input File: PDF, MD, TXT] --> Ext[Text Extractor]
     Ext -->|Markdown Converter| RawMD[Raw Markdown String]
     RawMD --> Chunk[Text Chunking]
-    Chunk -->|Iterative Chunks| LLM[LLM Entity Identification]
-    LLM --> Entity[Raw Entities List]
-    Entity --> Cons[Base Form Consolidation]
+    Chunk --> Regex[RE2 regex + checksums]
+    Chunk --> LLM[LLM Entity Identification]
+    Regex --> Merge[Merge detections]
+    LLM --> Merge
+    Merge --> Gaz[Keep-list / deny-list]
+    Gaz --> Cons[Base Form Consolidation]
     Cons --> MapGen[Placeholder Mapping Generator]
-    MapGen --> Repl[Text Replacement Engine]
-    Repl --> Output[Anonymized Markdown & JSON Map]
+    MapGen --> Ops[Per-type operators]
+    Ops --> Repl[Span-based replacement]
+    Repl --> Output[Anonymized Markdown and JSON map]
+    Output --> Verify[Residual leftover scan]
+    Output --> Risk[Linkage-risk score]
 ```
 
 ### Text Extraction & PDF Conversion
@@ -89,6 +95,33 @@ To solve coreference problems (e.g. associating "Dr. Smith", "Smith", and "Dr. J
 *   Mentions are located in the full document with word-boundary rules.
 *   Overlapping hits are resolved longest-first (`John Doe` wins over the inner `John`).
 *   Slices are written from the end of the string so earlier offsets stay valid.
+
+### Per-type operators
+*   Default write is still `replace` (`PERSON_1`).
+*   `--operator TYPE=mask|hash|generalize|shift|fake` changes how that type is written. `CREDIT_CARD_LIKE` follows `CREDIT_CARD`.
+*   `fake` is seeded (`--fake-secret` / `ANONYMIZER_FAKE_SECRET`) so the same person always gets the same invented name.
+*   Two dates that both become `2019` cannot both be restored uniquely.
+
+### Keep-list and deny-list
+*   Keep-list phrases stay visible even if regex or the model found them.
+*   Deny-list phrases become `CUSTOM_n` even if detection missed them.
+*   Keep wins if the same phrase is on both lists.
+
+### Cross-document maps
+*   `--mapping-in` seeds placeholder counts from an existing map (plaintext or encrypted).
+*   Files in one `run` share the growing map so Ada stays `PERSON_1`.
+
+### Encrypted mapping
+*   Default remains plaintext `*.mapping.json`.
+*   A passphrase (`--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY`) writes AES-256-GCM `*.mapping.json.enc`. `deanonymize` decrypts with the same key.
+
+### HIPAA coverage aid
+*   `--entity-profile hipaa-safe-harbor` (and `prompts.hipaa`) asks for the identifier *classes* that apply to text and applies year-only dates, ZIP3, age `90+`.
+*   This is an aid, not a compliance certificate. Pixels in photos are not hidden.
+
+### TAB-style eval harness
+*   `tests/eval/` scores mention-level and entity-level recall, split by direct vs quasi identifiers.
+*   `scripts/eval_tab.py` runs the mini fixture. Tests and scripts only — no product change.
 
 ---
 

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -159,8 +159,8 @@ Anonymize a meeting transcript using the default Gemini model:
 pdf-anonymizer run data/meeting_transcript.pdf
 ```
 *   **Outputs created**:
-    *   `data/meeting_transcript.anonymized.md` (the masked document)
-    *   `data/meeting_transcript.mapping.json` (the cryptographic key map)
+    *   `data/anonymized/meeting_transcript.anonymized.md` (the masked document)
+    *   `data/mappings/meeting_transcript.mapping.json` (the mapping file — treat it like a key)
 
 ### Example 2: Local Processing via Ollama
 To ensure data does not leave your local machine, use a locally running model:
@@ -178,22 +178,38 @@ pdf-anonymizer run book.md --characters-to-anonymize 50000 --prompt-name simple
 Revert the anonymization performed in Example 1:
 ```bash
 pdf-anonymizer deanonymize \
-  data/meeting_transcript.anonymized.md \
-  data/meeting_transcript.mapping.json
+  data/anonymized/meeting_transcript.anonymized.md \
+  data/mappings/meeting_transcript.mapping.json
 ```
 *   **Output created**:
-    *   `data/meeting_transcript.deanonymized.md`
+    *   `data/deanonymized/meeting_transcript.deanonymized.md`
+
+### Example 5: Newer flags in one command
+
+```bash
+pdf-anonymizer run notes.pdf contract.pdf \
+  -p best-quality \
+  --countries US,GB \
+  --operator CREDIT_CARD=mask \
+  --operator DATE=generalize \
+  --keep-list keep.txt \
+  --mapping-passphrase 'a long secret'
+```
+
+Files in the same `run` share one growing map, so the same person stays `PERSON_1`. See [Recipes](recipes.md) for keep-lists, HIPAA coverage aid, fake names, and `--mapping-in`.
 
 ---
 
 ## Output Files & Auditing
 
-Both commands write results under conventional directories (created automatically):
+`run`, `verify`, `report`, and `deanonymize` write under conventional directories (created automatically):
 
 *   `data/anonymized/<stem>.anonymized.md` (or `.txt`)
-*   `data/mappings/<stem>.mapping.json`
+*   `data/mappings/<stem>.mapping.json` (or `*.mapping.json.enc` when a passphrase is set)
 *   `data/deanonymized/<stem>.deanonymized.md` (or `.txt`)
-*   `data/stats/<stem>.deanonymization_stat.json`
+*   `data/stats/<stem>.residual_pii.json` — leftovers found after masking (from `run` or `verify`)
+*   `data/stats/<stem>.risk.json` — identity-clue clumps (from `run` or `report`)
+*   `data/stats/<stem>.deanonymization_stat.json` — written by `deanonymize`
 
 The stats file contains:
 
@@ -211,6 +227,62 @@ The stats file contains:
 *   `not_found_mappings`: placeholders seen in the text with no corresponding entry in the map (may indicate a corrupted or partial mapping).
 
 These are useful for compliance/audit pipelines. See the [Recipes & Common Workflows](recipes.md) page for more details on working with mappings and stats.
+
+---
+
+## History
+
+What the command line can do today, in the order those abilities landed. Default behaviour stayed the same unless you pass a flag. None of this is a legal certificate.
+
+### Identity clues (not only names)
+
+The careful instructions (`--prompt-name detailed`, used by `-p best-quality`) hide phrases that still pick out one person when no name is written — for example "the CEO of Tesla in Austin". Those become `PERSON_1` or `INDIRECT_1`. The short instructions (`simple`, used by `best-speed` and `best-cost`) do not hunt for this.
+
+### Checksums and `_LIKE` labels
+
+A number that *looks* like an IBAN or a card is still hidden if the extra check-digit fails. The stand-in says so: `IBAN_LIKE_1`, `CREDIT_CARD_LIKE_1`. A verified hit stays `IBAN_1`.
+
+### Limit national-ID patterns
+
+`--countries US,GB` keeps every universal pattern (email, IBAN, cards, …) and only the national IDs for those countries.
+
+### Leftover check
+
+`run` scans the masked page (unless `--no-verify`) and writes `data/stats/<stem>.residual_pii.json`. `pdf-anonymizer verify` does the same later. `--verify-llm` also asks the language model. The file is not rewritten.
+
+### Lock the mapping
+
+`--mapping-passphrase` (or `ANONYMIZER_MAPPING_KEY`) writes `*.mapping.json.enc` instead of plaintext JSON. `deanonymize` needs the same passphrase.
+
+### How a type is written
+
+`--operator TYPE=mask|hash|generalize|shift|fake` changes the mark on the page. Default remains `replace` (`PERSON_1`). Seed `fake` with `--fake-secret` / `ANONYMIZER_FAKE_SECRET`.
+
+### Linkage-risk score
+
+`run` writes `data/stats/<stem>.risk.json` unless `--no-risk`. `pdf-anonymizer report` scores an already-masked file. Report only; the page is not changed.
+
+### HIPAA Safe Harbor coverage aid
+
+`--entity-profile hipaa-safe-harbor` asks for the identifier *classes* that apply to text and writes year-only dates, ZIP3, and ages over 89 as `90+`. **Not a compliance certificate.**
+
+### Same stand-in across files
+
+`--mapping-in existing.mapping.json` seeds `PERSON_1`. Files in one `run` share the growing map.
+
+### Keep-list and deny-list
+
+`--keep-list` leaves listed phrases visible. `--deny-list` hides listed phrases even if detection missed them (`CUSTOM_n`). Keep wins if both lists contain the same phrase.
+
+### Span-based replacement
+
+Replacement is by character interval, not a blind search-and-replace. The longer span wins when two hits overlap (`John Doe` over the inner `John`). No extra flag.
+
+### TAB-style eval harness
+
+`tests/eval/` and `scripts/eval_tab.py` score mention-level and entity-level recall, split by direct identifiers (email, SSN) versus quasi-identifiers (city, date). Tests and scripts only — the product does not change.
+
+See [Recipes](recipes.md) for worked examples of each flag.
 
 ---
 

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -34,8 +34,12 @@ The project contains two decoupled Python packages inside `packages/`:
 Contains all the core engines, including:
 
 *   Text extraction from PDF, Markdown, and plain text formats.
+*   Hybrid detection: RE2 regex (with checksums / `TYPE_LIKE`) plus LLM NER.
 *   LLM router and adapters for various providers (Ollama, Gemini, OpenAI, etc.).
-*   System prompt templates (simple and detailed layouts).
+*   Prompt templates (`simple`, `detailed`, `hipaa`) and identity-clue detection.
+*   Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`, `fake`).
+*   Span-based replacement, keep/deny gazetteers, optional encrypted maps.
+*   Residual leftover scan, linkage-risk report, TAB-style eval helpers.
 *   Streaming chunk utility to process large text files.
 *   Mapping and restoration engine for deanonymization.
 
@@ -56,6 +60,6 @@ To dive deeper into the technical details, navigate through the following guides
 - **[CLI Reference](cli-usage.md)**: Explore the command-line arguments, options (including `--config-profile`), custom model strings, and usage examples.
 - **[SDK & API Usage](api-usage.md)**: Learn how to import PDF Anonymizer as a Python library in your own applications.
 - **[API Reference (auto)](api-reference.md)**: Living signature reference generated from source docstrings.
-- **[Recipes & Common Workflows](recipes.md)**: Practical end-to-end examples — fully local Ollama usage, safe external LLM workflows, batching, entity filtering, profiles, caching, debugging, and more.
+- **[Recipes & Common Workflows](recipes.md)**: Practical end-to-end examples — local Ollama, locked maps, operators, HIPAA aid, keep/deny lists, leftover checks, eval harness, batching, caching, and more.
 - **[Troubleshooting](troubleshooting.md)**: Common errors (auth, rate limits, LLM parsing, empty results, large files) and solutions.
 - **[Architecture Design](architecture.md)**: Understand the data flow, prompt styling, LLM adapters, and file splitting mechanisms.

--- a/docs/project/installation.md
+++ b/docs/project/installation.md
@@ -79,7 +79,15 @@ OPENROUTER_API_KEY="sk-or-v1-..."
 
 # Ollama Local Host (Optional, defaults to localhost:11434)
 OLLAMA_HOST="http://localhost:11434"
+
+# Optional: lock mapping files as *.mapping.json.enc (AES-256-GCM)
+ANONYMIZER_MAPPING_KEY="a long secret"
+
+# Optional: seed for --operator TYPE=fake (same person → same fake)
+ANONYMIZER_FAKE_SECRET="another long secret"
 ```
+
+`ANONYMIZER_MAPPING_KEY` and `ANONYMIZER_FAKE_SECRET` are optional. Without them, maps stay plaintext JSON and `fake` uses a built-in constant seed (stable, not private).
 
 ---
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -156,7 +156,7 @@ pdf-anonymizer run \
   -p best-cost
 ```
 
-Each file is processed independently. Results are written using the original stem name into the conventional output directories (`data/anonymized/`, `data/mappings/`, etc.).
+Files in the same `run` **share a growing map**, so Ada stays `PERSON_1` from the first file to the last. Results are written using the original stem name into the conventional output directories (`data/anonymized/`, `data/mappings/`, etc.). Use `--mapping-in` to continue a later batch from an earlier map.
 
 For very large batch jobs you may want to:
 - Use the faster/cheaper profile (`best-cost` or `best-speed`)
@@ -517,6 +517,34 @@ cfg = get_config_for_profile(ConfigProfile.BEST_SPEED, countries=["US", "GB"])
 ```
 
 This is a regex-stage setting only. The language model still reads the whole page and can name an ID from another country if the text is clear.
+
+---
+
+## Replacement is by span, not a blind search
+
+The tool does **not** walk the page and replace every copy of the letters `May`. It finds each mention as a *span* (a start and end character), keeps the longer span when two hits overlap (`John Doe` wins over the inner `John`), and writes replacements from the end of the string so earlier offsets stay valid.
+
+You do not turn this on. It is how replacement always works now.
+
+There is no extra CLI flag.
+
+---
+
+## Score a gold fixture (TAB-style eval)
+
+Unit tests check regexes and mappings. They do not tell you “how many real names did we miss?”.
+
+`tests/eval/` is a tiny gold page plus a scorer. It reports mention-level and entity-level precision / recall / F1, split by **direct** identifiers (email, SSN, person) versus **quasi** identifiers (city, date). That split matters: a high score on cities can hide a poor score on names.
+
+```bash
+# Run the regex stage on the built-in mini fixture
+uv run python scripts/eval_tab.py
+
+# Or score your own predictions JSON
+uv run python scripts/eval_tab.py --fixture tests/eval/fixture.json --predictions pred.json
+```
+
+This is tests and scripts only. It does not change `run`. It is not a legal privacy proof.
 
 ---
 

--- a/docs/project/troubleshooting.md
+++ b/docs/project/troubleshooting.md
@@ -16,7 +16,10 @@ Common problems and how to resolve them.
     HUGGING_FACE_TOKEN="hf_..."
     OPENROUTER_API_KEY="sk-or-..."
     OLLAMA_HOST="http://localhost:11434"
+    ANONYMIZER_MAPPING_KEY="a long secret"
+    ANONYMIZER_FAKE_SECRET="another long secret"
     ```
+  - `ANONYMIZER_MAPPING_KEY` locks mapping files as `*.mapping.json.enc`. `ANONYMIZER_FAKE_SECRET` seeds `--operator TYPE=fake`. Neither is required.
   - For the SDK, load the environment variables yourself (e.g. with `python-dotenv` or `os.environ`).
 
 ## Ollama Not Running or Model Not Found
@@ -45,7 +48,27 @@ Common problems and how to resolve them.
   - Check `app.log` — it shows how many entities were found by Regex vs LLM per chunk.
   - A number that *looks* like a card, IBAN, VIN, or national ID but fails the extra check-digit is still hidden, as `IBAN_LIKE_1` / `CREDIT_CARD_LIKE_1` and so on. That is expected for typos and example numbers such as `1234-5678-9012-3456`.
   - After a run, check `data/stats/<stem>.residual_pii.json` (or `pdf-anonymizer verify …`). Leftover emails or numbers listed there were not hidden.
+  - Check `data/stats/<stem>.risk.json` (or `pdf-anonymizer report …`). A **high** score means leftover identity clumps (job + company + place), not that names were missed.
+  - A keep-list phrase stays visible on purpose. A deny-list phrase becomes `CUSTOM_n` even if regex and the model missed it.
   - Very short documents or unusual formatting can reduce recall.
+
+## Encrypted mapping will not open
+
+- **Symptom**: `deanonymize` fails on `*.mapping.json.enc`, or you only have a `.enc` file and no passphrase.
+- **Fix**:
+  - Pass the same `--mapping-passphrase` you used with `run`, or set `ANONYMIZER_MAPPING_KEY`.
+  - There is no recovery path. The masked document plus a locked map without the passphrase cannot put names back.
+  - Default `run` still writes plaintext `*.mapping.json` if you set no passphrase.
+
+## A date or ZIP cannot be restored uniquely
+
+- **Symptom**: After `--operator DATE=generalize` (or HIPAA year-only dates), two different originals both became `2019`.
+- **Fix**: That is expected. Generalize, mask, and hash are not always one-to-one. Use `replace` (the default `PERSON_1`) when you need a unique round-trip.
+
+## `--entity-profile hipaa-safe-harbor` is not a certificate
+
+- That flag is a **coverage aid** (broader identifier classes, year-only dates, ZIP3, age 90+).
+- It does **not** mean the file is legally de-identified. It does not hide pixels in a photo. A person still has to read the result.
 
 ## LLM Returns Invalid JSON / Parsing Failures
 

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -5,6 +5,7 @@ A command-line interface for anonymizing PDF, Markdown, and plain text files usi
 - **High-Quality Anonymization**: Leverages LLMs to identify and replace Personally Identifiable Information (PII) with high accuracy.
 - **Identity clues**: With `-p best-quality` or `--prompt-name detailed`, the tool also hides phrases that point to one person without writing their name (for example "the CEO of Tesla"). The default `best-speed` profile does not.
 - **Checksum labels**: After the fast number search, a real IBAN becomes `IBAN_1` and a mistyped one becomes `IBAN_LIKE_1`. Both are hidden. Same idea for cards, VINs, and a few national IDs.
+- **Operators, reports, and lists**: `--operator TYPE=mask|hash|generalize|shift|fake`, leftover scan (`verify`), linkage-risk score (`report`), `--keep-list` / `--deny-list`, `--mapping-in`, optional locked maps, HIPAA coverage aid. See the [CLI History](https://leo-gan.github.io/anonymizer/project/cli-usage/#history).
 - **Large File Support**: Consistently anonymizes large files (tested up to 1GB).
 - **Multi-Provider & Cost-Effective**: Free to use with local [Ollama](https://ollama.com/) models. It also supports major providers like [OpenAI](https://openai.com/), [Anthropic](https://www.anthropic.com/), [Google](https://ai.google.com/), [Hugging Face](https://huggingface.co/), and [OpenRouter](https://openrouter.ai/).
 - **Reversible**: Supports deanonymization to recover original data when needed.
@@ -41,6 +42,8 @@ The CLI will automatically load a `.env` file from the current directory or any 
 - `OPENAI_API_KEY`: Required when using OpenAI models.
 - `ANTHROPIC_API_KEY`: Required when using Anthropic models.
 - `OLLAMA_HOST`: Optional, defaults to `http://localhost:11434` when using Ollama models.
+- `ANONYMIZER_MAPPING_KEY`: Optional. Same as `--mapping-passphrase` (writes `*.mapping.json.enc`).
+- `ANONYMIZER_FAKE_SECRET`: Optional. Seed for `--operator TYPE=fake`.
 
 Example `.env` file:
 ```env
@@ -136,12 +139,13 @@ pdf-anonymizer run report.pdf --model-name "openai/gpt-4o"
 The `deanonymize` command reverts anonymization using a mapping file.
 
 ```bash
-pdf-anonymizer deanonymize ANONYMIZED_FILE MAPPING_FILE
+pdf-anonymizer deanonymize ANONYMIZED_FILE MAPPING_FILE [--mapping-passphrase TEXT]
 ```
 
 **Arguments**:
 - `ANONYMIZED_FILE`: Path to the anonymized text file.
-- `MAPPING_FILE`: Path to the JSON mapping file.
+- `MAPPING_FILE`: Path to the JSON mapping file (plaintext or `*.mapping.json.enc`).
+- `--mapping-passphrase`: Required for an encrypted mapping. Also `ANONYMIZER_MAPPING_KEY`.
 
 **Example**:
 ```bash

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.13.0"
+version = "0.14.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -36,6 +36,8 @@ The core library itself does not load `.env` files. Environment variables must b
 - `OPENAI_API_KEY`: Required when using OpenAI models.
 - `ANTHROPIC_API_KEY`: Required when using Anthropic models.
 - `OLLAMA_HOST`: Optional, defaults to `http://localhost:11434` when using Ollama models.
+- `ANONYMIZER_MAPPING_KEY`: Optional passphrase for encrypted mapping files.
+- `ANONYMIZER_FAKE_SECRET`: Optional seed for the `fake` operator.
 
 ## API Usage
 
@@ -123,6 +125,10 @@ Pass `seed_mapping=` (original → written) into `anonymize_file` so the same pe
 `EntityProfile.HIPAA_SAFE_HARBOR` is a coverage aid for Safe Harbor identifier classes (year-only dates, ZIP3, age 90+). It is **not** a compliance certificate.
 
 Per-type operators (`replace`, `mask`, `hash`, `generalize`, `shift`, `fake`) go in `operators={"PERSON": "fake"}` on `anonymize_file`. Pass `fake_secret=` so the same person always gets the same fake.
+
+Replacement is span-based: mentions are located in the full document, the longer interval wins on overlap, and slices are written from the end.
+
+To score a gold fixture (mention vs entity recall, direct vs quasi) run `uv run python scripts/eval_tab.py`. Tests and scripts only.
 
 To score identity-clue clumps in masked text (report only):
 

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.13.0"
+version = "0.14.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -51,8 +51,8 @@ def anonymize_file(
     Performs a two-stage entity detection (fast regex first pass followed by
     LLM-based semantic detection), deduplicates, consolidates base forms for
     coreference (e.g. "Dr. Smith" / "Smith"), generates typed placeholders
-    (PERSON_1, ORGANIZATION_3.v_1, ...), and performs length-descending safe
-    replacement to produce reversible anonymized output.
+    (PERSON_1, ORGANIZATION_3.v_1, ...), and replaces non-overlapping spans
+    (longest-first, written from the end) to produce reversible anonymized output.
 
     The function streams large inputs via chunking (Markdown-aware for PDF/MD)
     so that very large files (hundreds of MB) can be processed without
@@ -80,8 +80,8 @@ def anonymize_file(
         base_retry_delay: Base delay in seconds for retry backoff.
         max_retry_delay: Maximum delay cap for retry backoff.
         operators: Optional map of entity type → operator (replace, mask, hash,
-            generalize, shift). Types not listed keep ``replace``. ``CREDIT_CARD_LIKE``
-            follows ``CREDIT_CARD``.
+            generalize, shift, fake). Types not listed keep ``replace``.
+            ``CREDIT_CARD_LIKE`` follows ``CREDIT_CARD``.
         fake_secret: Optional seed material for the ``fake`` operator. Same
             person + type + secret always yields the same fake.
         seed_mapping: Optional original → written map from a previous file so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Public docs were behind the work that already merged in PRs #40–#52.

- Adds a **[History](https://leo-gan.github.io/anonymizer/project/cli-usage/#history)** section on the CLI page (flag-by-flag list of what landed).
- Updates every published 101 and project page, plus the root and package READMEs, so they match shipped behaviour (checksums / `TYPE_LIKE`, operators, locked maps, leftover and risk reports, HIPAA aid, keep/deny, span replacement, eval harness).
- Fixes stale output paths, the broken 101 History “next” link (`where-needed.md` → `techniques.md`), and the `anonymize_file` docstring that still said search-and-replace.

Packages: **0.13.0 → 0.14.0**.

No product behaviour change.

## Tests

`uv run ruff check .`, `uv run pytest` (131 tests), and `uv run mkdocs build --strict` pass locally.