### PR TITLE
feat: add regex-only offline mode that skips the language model

### DIFF
--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -21,7 +21,7 @@
 - [x] 13. TAB-style eval harness — done 2026-08-15, [PR #52](https://github.com/leo-gan/anonymizer/pull/52)
 - [ ] 14. OCR for scanned PDFs
 - [ ] 15. In-place PDF redaction
-- [ ] 16. Regex-only / offline mode
+- [x] 16. Regex-only / offline mode — done 2026-08-15, [PR #55](https://github.com/leo-gan/anonymizer/pull/55)
 - [x] 17. Secure mapping encryption workflow (Argon2id, AAD, 0600, ephemeral, wipe) — done 2026-08-15, [PR #54](https://github.com/leo-gan/anonymizer/pull/54)
 
 ---
@@ -355,7 +355,7 @@ Known code facts to attach to:
 
 ### 16. Regex-only / offline mode
 
-**Status:** in progress (2026-08-15) — `feat/regex-only-offline-mode`
+**Status:** done (2026-08-15) — [PR #55](https://github.com/leo-gan/anonymizer/pull/55) (`feat/regex-only-offline-mode`)
 
 **Technique:** data removal without a language model.  
 **Why:** Air-gapped machines, cost, or structured logs where regex is enough.

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -58,6 +58,7 @@ Known code facts to attach to:
 - `--operator TYPE=mask|hash|generalize|shift|fake` changes how a type is written. Default remains `replace` (PERSON_1).
 - `--entity-profile hipaa-safe-harbor` is a coverage aid (year-only dates, ZIP3, age 90+). Not a compliance certificate.
 - National-ID regexes can be limited with `filter_regex_patterns(["US", "GB"])` or CLI `--countries US,GB`. Universal patterns always stay.
+- `--no-llm` / `-p regex-only` skips the language model. Regex, checksums, operators, verify, and risk still run. Names and identity clues are missed.
 - `--keep-list` / `--deny-list` gazetteers. Keep wins if a phrase is on both lists.
 - `tests/eval/` scores mention-level and entity-level recall, split by direct vs quasi identifiers. `scripts/eval_tab.py` runs the fixture (regex stage if no predictions file). No product behavior change.
 
@@ -353,6 +354,8 @@ Known code facts to attach to:
 ---
 
 ### 16. Regex-only / offline mode
+
+**Status:** in progress (2026-08-15) — `feat/regex-only-offline-mode`
 
 **Technique:** data removal without a language model.  
 **Why:** Air-gapped machines, cost, or structured logs where regex is enough.

--- a/docs/project/api-usage.md
+++ b/docs/project/api-usage.md
@@ -167,7 +167,7 @@ write_residual_report(verify_anonymized_text(anonymized_text), anonymized_path)
 write_risk_report(assess_linkage_risk(anonymized_text), anonymized_path)
 ```
 
-For the complete `anonymize_file` signature (including `chunk_overlap`, `regex_patterns`, `max_retries`, `operators`, `seed_mapping`, gazetteers, etc.) see the [auto-generated API Reference](api-reference.md) or the Recipes page.
+For the complete `anonymize_file` signature (including `chunk_overlap`, `regex_patterns`, `max_retries`, `operators`, `seed_mapping`, gazetteers, `use_llm`, etc.) see the [auto-generated API Reference](api-reference.md) or the Recipes page. Pass `use_llm=False` (or `-p regex-only` / `--no-llm` on the CLI) to skip the language model.
 
 ---
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -111,6 +111,9 @@ To solve coreference problems (e.g. associating "Dr. Smith", "Smith", and "Dr. J
 *   `--mapping-in` seeds placeholder counts from an existing map (plaintext or encrypted).
 *   Files in one `run` share the growing map so Ada stays `PERSON_1`.
 
+### Regex-only / offline
+*   `--no-llm` or `-p regex-only` skips the language model. Regex, checksums, operators, leftover scan, and risk still run. Names and identity clues are missed.
+
 ### Encrypted mapping
 *   Default remains plaintext `*.mapping.json`.
 *   A passphrase (`--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY`) writes AES-256-GCM + Argon2id `*.mapping.json.enc`. The source file SHA-256 and schema version are bound as GCM AAD. Mapping files (plain or locked) are written atomically as mode `0600`.

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -20,7 +20,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `--config-profile` / `-p` | `best-quality` \| `best-speed` \| `best-cost` | `best-speed` | Predefined bundle of model, prompt, chunk size, overlap, and retry settings (see below). |
+| `--config-profile` / `-p` | `best-quality` \| `best-speed` \| `best-cost` \| `regex-only` | `best-speed` | Predefined bundle of model, prompt, chunk size, overlap, and retry settings (see below). `regex-only` skips the language model. |
+| `--no-llm` | flag | off | Skip the language model. Only the RE2 regex stage runs. Names and identity clues will be missed. Same as `-p regex-only`. |
 | `--characters-to-anonymize` | `INTEGER` | `100000` | The character size of each chunk sent to the LLM (overrides profile). |
 | `--prompt-name` | `simple` \| `detailed` | `detailed` | Instruction style sent to the language model (overrides profile). `detailed` also hides identity clues. `simple` does not. |
 | `--model-name` | `TEXT` | `gemini-2.5-flash` | The identifier of the model to execute (overrides profile). |
@@ -47,6 +48,7 @@ The `--config-profile` (or `-p`) flag is the recommended way to select quality/s
 | `best-quality` | `gemini-2.5-pro`        | detailed | 15,000     | 2,000   | 5       | Highest accuracy; also hides identity clues (slower/costlier)|
 | `best-speed`   | `gemini-2.5-flash`      | simple   | 30,000     | 1,000   | 3       | Balanced (default); does not hunt for identity clues |
 | `best-cost`    | `gemini-2.5-flash-lite` | simple   | 60,000     | 3,000   | 3       | Cheap & fast on long documents; no identity-clue hunt |
+| `regex-only`   | none                    | simple   | 200,000    | 0       | 1       | Offline / air-gapped: regex only. Names and identity clues are missed |
 
 **Examples**
 
@@ -247,6 +249,10 @@ A number that *looks* like an IBAN or a card is still hidden if the extra check-
 ### Limit national-ID patterns
 
 `--countries US,GB` keeps every universal pattern (email, IBAN, cards, …) and only the national IDs for those countries.
+
+### Regex-only / offline
+
+`--no-llm` or `-p regex-only` skips the language model. Emails, cards, IBANs, and other structured hits are still hidden (including `_LIKE` checksum failures). Operators, leftover scan, and linkage-risk still run. No API key is required. **Names and identity clues will be missed.** `--verify-llm` is ignored so the process stays offline.
 
 ### Leftover check
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -51,6 +51,42 @@ anonymized, mapping = anonymize_file(
 
 ---
 
+## Regex-only / offline (no language model)
+
+Air-gapped machines, structured logs, or a cheap first pass: skip the model. Only the RE2 regex stage runs. Checksums (`IBAN_LIKE_1`), `--countries`, `--operator`, leftover scan, and linkage-risk still run. **Names and identity clues will be missed.**
+
+**CLI**
+
+```bash
+pdf-anonymizer run access.log --no-llm
+# or
+pdf-anonymizer run access.log -p regex-only
+```
+
+No API key is required. `--verify-llm` is ignored in this mode so the process stays offline.
+
+**SDK (Python)**
+
+```python
+from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.conf import get_config_for_profile, ConfigProfile
+
+config = get_config_for_profile(ConfigProfile.REGEX_ONLY)
+anonymized, mapping = anonymize_file(
+    file_path="access.log",
+    characters_to_anonymize=config.chunk_size,
+    prompt_template="",
+    model_name=config.model_name,
+    chunk_overlap=config.chunk_overlap,
+    regex_patterns=config.regex_patterns,
+    use_llm=False,
+)
+```
+
+`use_llm` defaults to True. Existing callers are unchanged.
+
+---
+
 ## Anonymize → Send to External AI / Service → Deanonymize Locally
 
 The classic reversible workflow: protect the original data, let an untrusted system (public ChatGPT, Claude, a third-party analysis service, translation pipeline, etc.) work on the masked version, then recover the real values locally.

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -60,7 +60,8 @@ The `run` command anonymizes one or more files.
 
 ```bash
 pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
-  [-p | --config-profile {best-quality|best-speed|best-cost}] \
+  [-p | --config-profile {best-quality|best-speed|best-cost|regex-only}] \
+  [--no-llm] \
   [--characters-to-anonymize INTEGER] \
   [--prompt-name {simple|detailed}] \
   [--model-name TEXT] \
@@ -74,7 +75,8 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 - `FILE_PATH`: Path to one or several PDF, Markdown, or text files for anonymization.
 
 **Options**:
-- `-p, --config-profile {best-quality|best-speed|best-cost}`: The configuration profile to use. Profiles bundle sensible defaults for model, prompt, chunk size, overlap, and retries (default: `best-speed`). Individual flags (`--model-name`, `--prompt-name`, `--characters-to-anonymize`) act as overrides on top of the chosen profile.
+- `-p, --config-profile {best-quality|best-speed|best-cost|regex-only}`: The configuration profile to use. Profiles bundle sensible defaults for model, prompt, chunk size, overlap, and retries (default: `best-speed`). `regex-only` skips the language model. Individual flags (`--model-name`, `--prompt-name`, `--characters-to-anonymize`) act as overrides on top of the chosen profile.
+- `--no-llm`: Skip the language model. Only the RE2 regex stage runs. Names and identity clues will be missed. Same as `-p regex-only`.
 - `--characters-to-anonymize INTEGER`: Number of characters to process in each chunk (default: `100000`; overrides profile).
 - `--prompt-name [simple|detailed]`: The prompt template to use (default: `detailed`; overrides profile).
 - `--model-name TEXT`: The language model to use (overrides profile).

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.15.0"
+version = "0.16.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -68,7 +68,7 @@ def run(
         typer.Option(
             "--config-profile",
             "-p",
-            help="The configuration profile to use (best-quality, best-speed, best-cost).",
+            help="The configuration profile to use (best-quality, best-speed, best-cost, regex-only).",
             case_sensitive=False,
         ),
     ] = ConfigProfile.BEST_SPEED,
@@ -131,6 +131,18 @@ def run(
         typer.Option(
             "--verify-llm/--no-verify-llm",
             help="Also ask the language model to hunt for leftovers (slower).",
+        ),
+    ] = False,
+    no_llm: Annotated[
+        bool,
+        typer.Option(
+            "--no-llm",
+            help=(
+                "Skip the language model. Only the RE2 regex stage runs. "
+                "Checksums, country filter, operators, leftover scan, and "
+                "risk still run. Names and identity clues will be missed. "
+                "Same as -p regex-only. Default: use the model."
+            ),
         ),
     ] = False,
     mapping_passphrase: Annotated[
@@ -264,26 +276,38 @@ def run(
         logging.error("%s", exc)
         sys.exit(1)
 
-    # Configure LLM caching with values from configuration
-    configure_cache(
-        enabled=config.enable_cache,
-        cache_dir=config.cache_dir,
-        cache_file=config.cache_file,
-    )
+    use_llm = bool(config.use_llm) and not no_llm
+    if not use_llm:
+        logging.info(
+            "Regex-only / offline mode: skipping the language model. "
+            "Names and identity clues will be missed."
+        )
+        if verify_llm:
+            logging.warning("--verify-llm is ignored when the language model is off.")
+            verify_llm = False
 
-    provider_name, _ = get_provider_and_model_name(config.model_name)
-    if provider_name == "google":
-        if "gemini" in config.model_name and not os.getenv("GOOGLE_API_KEY"):
-            logging.error(
-                "Error: GOOGLE_API_KEY not found. Please set it in the .env file."
-            )
-            sys.exit(1)
+    if use_llm:
+        # Configure LLM caching with values from configuration
+        configure_cache(
+            enabled=config.enable_cache,
+            cache_dir=config.cache_dir,
+            cache_file=config.cache_file,
+        )
+
+        provider_name, _ = get_provider_and_model_name(config.model_name)
+        if provider_name == "google":
+            if "gemini" in config.model_name and not os.getenv("GOOGLE_API_KEY"):
+                logging.error(
+                    "Error: GOOGLE_API_KEY not found. Please set it in the .env file."
+                )
+                sys.exit(1)
 
     logging.info(f"Using configuration profile: {config_profile.value}")
     logging.info(f"  --file-paths: {file_paths}")
     logging.info(f"  --chunk-size: {config.chunk_size}")
     logging.info(f"  --chunk-overlap: {config.chunk_overlap}")
     logging.info(f"  --model-name: {config.model_name}")
+    logging.info(f"  --use-llm: {use_llm}")
     if country_list:
         logging.info(f"  --countries: {country_list}")
         logging.info(
@@ -364,6 +388,7 @@ def run(
             seed_mapping=seed_mapping,
             keep_list=keep_phrases,
             deny_list=deny_phrases,
+            use_llm=use_llm,
         )
 
         if full_anonymized_text and final_mapping:

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.15.0"
+version = "0.16.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
@@ -2,8 +2,8 @@
 
 This module defines:
 - Default constants and directories used by the anonymizer.
-- Three built-in ConfigProfiles (best-quality, best-speed, best-cost) that
-  bundle sensible combinations of model, prompt, chunk size, retries, etc.
+- Built-in ConfigProfiles (best-quality, best-speed, best-cost, regex-only)
+  that bundle model, prompt, chunk size, retries, and whether to call an LLM.
 - The AppConfig Pydantic model.
 - get_config_for_profile() helper (used heavily by the CLI).
 - Legacy enums (PromptEnum, ModelName, etc.) for compatibility and
@@ -98,7 +98,6 @@ DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
     "VIN": r"\b[A-HJ-NPR-Z0-9]{17}\b",
     # Common machine / log / API date-time formats (ISO-8601 and close variants)
     "DATE_ISO": r"\b\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})?)?\b",
-
     # ---------- UNITED STATES (US) ----------
     "SSN_US": r"\b\d{3}-\d{2}-\d{4}\b",
     "EIN_US": r"\b\d{2}-\d{7}\b",  # Employer Identification Number / US tax ID for businesses
@@ -108,88 +107,72 @@ DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
     "MEDICAL_NPI_US": r"\b[0-9]{10}\b",  # National Provider Identifier (10 digits)
     # Medical / DEA style controlled substance license (example structural)
     "MEDICAL_LICENSE_US": r"\b[A-Z]{1,2}\d{6,9}\b",
-
     # ---------- CANADA (CA) ----------
     "SIN_CA": r"\b\d{3}-\d{3}-\d{3}\b",  # Social Insurance Number
     "CA_PASSPORT": r"\b[A-Z]{2}\d{6}\b",
     "DRIVERS_LICENSE_CA": r"\b[A-Z]\d{4,5}-\d{5,6}-\d{5}\b|\b[A-Z0-9]{5,15}\b",  # varies by province
-
     # ---------- UNITED KINGDOM (GB) ----------
     "NINO_GB": r"\b[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}\d{6}[A-DFM]?\b",  # National Insurance Number
     "GB_PASSPORT": r"\b[0-9]{9}\b",
     "DRIVERS_LICENSE_GB": r"\b[A-Z9]{5}\d{6}[A-Z9]{2}\d[A-Z]{2}\b",  # 16 char UK DL number (approx structural)
     "VAT_GB": r"\bGB\d{9}\b|\bGB\d{12}\b|\bGBGD\d{3}\b|\bGBHA\d{3}\b",
     "COMPANIES_HOUSE_GB": r"\b(?:SC|NI|OC|SO)?\d{6,8}\b",  # Company number
-
     # ---------- FRANCE (FR) ----------
     "INSEE_FR": r"\b[12]\d{12,14}\b",  # NIR / INSEE (simplified for RE2 recall; LLM validates)
     "VAT_FR": r"\bFR[A-HJ-NP-Z0-9]{2}\d{9}\b",
     "DRIVERS_LICENSE_FR": r"\b[A-Z0-9]{12}\b",  # French permis (approx)
     "PASSPORT_FR": r"\b\d{2}[A-Z]{2}\d{5}\b",
-
     # ---------- SPAIN (ES) ----------
     "DNI_ES": r"\b\d{8}[A-HJ-NP-TV-Z]\b",
     "NIE_ES": r"\b[XYZ]\d{7}[A-HJ-NP-TV-Z]\b",
     "CIF_ES": r"\b[A-HJ-NP-S]\d{7}[A-J0-9]\b",  # Company tax ID
     "VAT_ES": r"\bES[A-Z0-9]\d{7}[A-Z0-9]\b",
     "DRIVERS_LICENSE_ES": r"\b[A-Z0-9]{9,10}\b",
-
     # ---------- ITALY (IT) ----------
     "CODICE_FISCALE_IT": r"\b[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]\b",
     "VAT_IT": r"\bIT\d{11}\b",
     "DRIVERS_LICENSE_IT": r"\b[A-Z0-9]{10}\b",
-
     # ---------- INDIA (IN) ----------
     "AADHAAR_IN": r"\b\d{4}\s?\d{4}\s?\d{4}\b",
     "PAN_IN": r"\b[A-Z]{5}\d{4}[A-Z]\b",  # Permanent Account Number
     "GSTIN_IN": r"\b\d{2}[A-Z]{5}\d{4}[A-Z]\d[A-Z0-9]{2}\b",
     "DRIVERS_LICENSE_IN": r"\b[A-Z]{2}\d{2}\s?\d{11}\b|\b[A-Z]{2}-\d{13}\b",
-
     # ---------- CHINA (CN) ----------
     "RESIDENT_ID_CN": r"\b\d{17}[\dXx]\b",  # 18-digit Resident Identity Card (last may be X)
     "UNIFIED_SOCIAL_CREDIT_CODE_CN": r"\b[A-Z0-9]{18}\b",  # USCC / 统一社会信用代码
     "PASSPORT_CN": r"\bE\d{8}\b|\bG\d{8}\b|\bS\d{8}\b",  # Common formats
-
     # ---------- GERMANY (DE) ----------
     "STEUER_ID_DE": r"\b\d{11}\b",  # Personal tax ID (11 digits)
     "VAT_DE": r"\bDE\d{9}\b",
     "PERSONALAUSWEIS_DE": r"\b[A-Z0-9]{9,10}\b",  # approx ID card / passport style
     "DRIVERS_LICENSE_DE": r"\b[A-Z0-9]{11,12}\b",
-
     # ---------- JAPAN (JP) ----------
     "MY_NUMBER_JP": r"\b\d{4}\s?\d{4}\s?\d{4}\b",  # 12-digit Individual Number
     "RESIDENT_CARD_JP": r"\b[A-Z]{2}\d{8}\b",  # approx
     "DRIVERS_LICENSE_JP": r"\b\d{12}\b",
-
     # ---------- SOUTH KOREA (KR) ----------
     "RESIDENT_REGISTRATION_KR": r"\b\d{6}-\d{7}\b",  # RRN (with dash)
     "BUSINESS_REG_KR": r"\b\d{3}-\d{2}-\d{5}\b",
-
     # ---------- AUSTRALIA (AU) / NEW ZEALAND (NZ) ----------
     "TFN_AU": r"\b\d{3}\s?\d{3}\s?\d{3}\b",  # Tax File Number
     "ABN_AU": r"\b\d{2}\s?\d{3}\s?\d{3}\s?\d{3}\b",  # Australian Business Number
     "DRIVERS_LICENSE_AU": r"\b[A-Z0-9]{8,10}\b",
     "IRD_NZ": r"\b\d{2,3}-\d{3,4}-\d{3}\b",  # IRD number (tax)
-
     # ---------- BRAZIL (BR) ----------
     "CPF_BR": r"\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b",  # Pessoa Física
     "CNPJ_BR": r"\b\d{2}\.?\d{3}\.?\d{3}/?\d{4}-?\d{2}\b",  # Pessoa Jurídica (business)
     "RG_BR": r"\b\d{2}\.?\d{3}\.?\d{3}-?[0-9X]\b",
-
     # ---------- MEXICO (MX) / ARGENTINA (AR) ----------
     "CURP_MX": r"\b[A-Z]{4}\d{6}[HM][A-Z]{5}[0-9A-Z]\d\b",
     "RFC_MX": r"\b[A-Z]{3,4}\d{6}[A-Z0-9]{3}\b",
     "DNI_AR": r"\b\d{8}\b",  # Argentine ID (often 8 digits + verification in context)
-
     # ---------- SOUTH AFRICA (ZA) ----------
     "ID_ZA": r"\b\d{13}\b",  # 13-digit SA ID
     "TAX_ZA": r"\b\d{10}\b",
-
     # ---------- SINGAPORE (SG) / HONG KONG (HK) / TAIWAN (TW) ----------
     "NRIC_SG": r"\b[SGT]\d{7}[A-Z]\b",  # National Registration Identity Card
     "HKID_HK": r"\b[A-Z]{1,2}\d{6}[0-9A]\b",
     "NATIONAL_ID_TW": r"\b[A-Z]\d{9}\b",
-
     # ---------- EUROPE (selected other) ----------
     "BSN_NL": r"\b\d{9}\b",  # Burgerservicenummer (NL)
     "VAT_NL": r"\bNL\d{9}B\d{2}\b",
@@ -205,7 +188,6 @@ DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
     "PPS_IE": r"\b\d{7}[A-W]\b",  # Personal Public Service Number (IE)
     "NIF_PT": r"\b\d{9}\b",
     "AMKA_GR": r"\b\d{11}\b",
-
     # ---------- MIDDLE EAST / OTHER ----------
     "ID_IL": r"\b\d{9}\b",  # Israeli ID (Teudat Zehut)
     "NATIONAL_ID_TR": r"\b\d{11}\b",  # Turkish TC Kimlik
@@ -213,7 +195,6 @@ DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
     "NATIONAL_ID_TH": r"\b\d{13}\b",  # Thai ID
     "NRIC_MY": r"\b\d{6}-\d{2}-\d{4}\b",  # Malaysian
     "NIK_ID": r"\b\d{16}\b",  # Indonesian
-
     # ---------- Legacy / aliases kept for compatibility ----------
     "SSN": r"\b\d{3}-\d{2}-\d{4}\b",  # maps to US SSN
 }
@@ -322,6 +303,7 @@ class ConfigProfile(str, Enum):
     BEST_QUALITY = "best-quality"
     BEST_SPEED = "best-speed"
     BEST_COST = "best-cost"
+    REGEX_ONLY = "regex-only"
 
 
 class EntityProfile(str, Enum):
@@ -415,6 +397,17 @@ PROFILE_CONFIGS: Dict[ConfigProfile, Dict[str, Any]] = {
         "base_retry_delay": 1.0,
         "max_retry_delay": 15.0,
     },
+    ConfigProfile.REGEX_ONLY: {
+        "model_name": "none",
+        "prompt_name": "simple",
+        "chunk_size": 200000,
+        "chunk_overlap": 0,
+        "max_retries": 1,
+        "base_retry_delay": 1.0,
+        "max_retry_delay": 1.0,
+        "use_llm": False,
+        "enable_cache": False,
+    },
 }
 
 
@@ -437,6 +430,7 @@ class AppConfig(BaseModel):
     regex_patterns: Dict[str, str] = Field(
         default_factory=lambda: dict(DEFAULT_REGEX_PATTERNS)
     )
+    use_llm: bool = True
 
 
 def get_config_for_profile(
@@ -457,7 +451,8 @@ def get_config_for_profile(
     come from the chosen profile.
 
     Args:
-        profile: One of ConfigProfile.BEST_QUALITY, BEST_SPEED or BEST_COST.
+        profile: One of ConfigProfile.BEST_QUALITY, BEST_SPEED, BEST_COST,
+            or REGEX_ONLY.
         model_name: Optional override for the model (string or provider/model).
         prompt_name: Optional override ("simple" or "detailed").
         chunk_size: Optional override for characters_to_anonymize / chunk_size.
@@ -488,6 +483,8 @@ def get_config_for_profile(
         base_retry_delay=profile_defaults["base_retry_delay"],
         max_retry_delay=profile_defaults["max_retry_delay"],
         regex_patterns=filter_regex_patterns(countries),
+        use_llm=profile_defaults.get("use_llm", True),
+        enable_cache=profile_defaults.get("enable_cache", True),
     )
 
 

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -45,6 +45,7 @@ def anonymize_file(
     seed_mapping: Optional[Dict[str, str]] = None,
     keep_list: Optional[List[str]] = None,
     deny_list: Optional[List[str]] = None,
+    use_llm: bool = True,
 ) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
     """Anonymize a file by processing its text content.
 
@@ -88,6 +89,9 @@ def anonymize_file(
             the same person keeps PERSON_1 (or the same fake) across documents.
         keep_list: Phrases that must stay visible even if detected.
         deny_list: Phrases that must be replaced even if detection missed them.
+        use_llm: When False, skip ``identify_entities_with_llm``. Regex,
+            checksums, operators, gazetteers, and span replacement still run.
+            Names and identity clues will be missed. Default True.
 
     Returns:
         A tuple (anonymized_text, mapping) where:
@@ -119,6 +123,12 @@ def anonymize_file(
     # Accumulate all entities from all chunks
     collected_entities: List[dict] = []
 
+    if not use_llm:
+        logging.info(
+            "Regex-only / offline mode: skipping the language model. "
+            "Names and identity clues will be missed."
+        )
+
     for i, text_page in enumerate(text_pages):
         logging.info(f"Identifying entities in part {i + 1}/{len(text_pages)}...")
         start_time = time.time()
@@ -126,21 +136,25 @@ def anonymize_file(
         # 1st Stage: Regex NER
         regex_entities = extract_entities_via_regex(text_page, regex_patterns)
 
-        # 2nd Stage: LLM NER
-        llm_entities = identify_entities_with_llm(
-            text_page,
-            prompt_template,
-            model_name,
-            max_retries=max_retries,
-            base_retry_delay=base_retry_delay,
-            max_retry_delay=max_retry_delay,
-        )
+        # 2nd Stage: LLM NER (optional)
+        if use_llm:
+            llm_entities = identify_entities_with_llm(
+                text_page,
+                prompt_template,
+                model_name,
+                max_retries=max_retries,
+                base_retry_delay=base_retry_delay,
+                max_retry_delay=max_retry_delay,
+            )
+        else:
+            llm_entities = []
 
         end_time = time.time()
         duration = end_time - start_time
         minutes = int(duration // 60)
         seconds = int(duration % 60)
-        logging.info(f"   NER stage duration (Regex + LLM): {minutes}:{seconds:02d}")
+        stage = "Regex + LLM" if use_llm else "Regex only"
+        logging.info(f"   NER stage duration ({stage}): {minutes}:{seconds:02d}")
         logging.info(
             f"   Found {len(regex_entities)} via Regex, {len(llm_entities)} via LLM."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_regex_only.py
+++ b/tests/test_regex_only.py
@@ -1,0 +1,128 @@
+"""Regex-only / offline mode: skip the LLM, keep the rest of the pipeline."""
+
+from pdf_anonymizer_core.conf import ConfigProfile, get_config_for_profile
+from pdf_anonymizer_core.core import anonymize_file
+
+
+def _stub_file(mocker, text: str) -> None:
+    mocker.patch("os.path.getsize", return_value=len(text))
+    mocker.patch(
+        "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+        return_value=(text, [text]),
+    )
+
+
+class TestAnonymizeWithoutLlm:
+    def test_skips_llm_and_still_masks_structured_pii(self, mocker) -> None:
+        text = "Write to ada@example.com about Ada Lovelace."
+        _stub_file(mocker, text)
+        llm = mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "Ada Lovelace",
+                    "type": "PERSON",
+                    "base_form": "Ada Lovelace",
+                }
+            ],
+        )
+        anonymized, mapping = anonymize_file(
+            "dummy.txt", 1000, "unused", "unused", use_llm=False
+        )
+        llm.assert_not_called()
+        assert "ada@example.com" not in anonymized
+        assert "EMAIL_1" in anonymized
+        assert mapping["ada@example.com"] == "EMAIL_1"
+        # Names and identity clues are not a regex job.
+        assert "Ada Lovelace" in anonymized
+        assert "PERSON_1" not in anonymized
+
+    def test_default_still_calls_the_language_model(self, mocker) -> None:
+        text = "Hello Ada Lovelace"
+        _stub_file(mocker, text)
+        llm = mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "Ada Lovelace",
+                    "type": "PERSON",
+                    "base_form": "Ada Lovelace",
+                }
+            ],
+        )
+        mocker.patch(
+            "pdf_anonymizer_core.core.extract_entities_via_regex",
+            return_value=[],
+        )
+        anonymized, mapping = anonymize_file("dummy.txt", 1000, "dummy", "dummy")
+        llm.assert_called_once()
+        assert anonymized == "Hello PERSON_1"
+        assert mapping["Ada Lovelace"] == "PERSON_1"
+
+    def test_checksum_like_labels_still_apply(self, mocker) -> None:
+        text = "Pay DE89370400440532013000 or GB00WEST12345698765432."
+        _stub_file(mocker, text)
+        llm = mocker.patch("pdf_anonymizer_core.core.identify_entities_with_llm")
+        anonymized, mapping = anonymize_file(
+            "dummy.txt", 1000, "unused", "unused", use_llm=False
+        )
+        llm.assert_not_called()
+        assert "DE89370400440532013000" not in anonymized
+        assert "GB00WEST12345698765432" not in anonymized
+        assert "IBAN_1" in anonymized
+        assert "IBAN_LIKE_1" in anonymized
+        assert mapping["DE89370400440532013000"] == "IBAN_1"
+        assert mapping["GB00WEST12345698765432"] == "IBAN_LIKE_1"
+
+    def test_operators_still_run(self, mocker) -> None:
+        text = "Card 4111 1111 1111 1111"
+        _stub_file(mocker, text)
+        mocker.patch("pdf_anonymizer_core.core.identify_entities_with_llm")
+        anonymized, mapping = anonymize_file(
+            "dummy.txt",
+            1000,
+            "unused",
+            "unused",
+            operators={"CREDIT_CARD": "mask"},
+            use_llm=False,
+        )
+        assert "4111 1111 1111 1111" not in anonymized
+        assert "CREDIT_CARD_1" not in anonymized
+        assert mapping["4111 1111 1111 1111"] != "CREDIT_CARD_1"
+
+    def test_country_filter_still_applies(self, mocker) -> None:
+        from pdf_anonymizer_core.conf import filter_regex_patterns
+
+        text = "US 123-45-6789 and GB AA123456C"
+        _stub_file(mocker, text)
+        mocker.patch("pdf_anonymizer_core.core.identify_entities_with_llm")
+        anonymized, mapping = anonymize_file(
+            "dummy.txt",
+            1000,
+            "unused",
+            "unused",
+            regex_patterns=filter_regex_patterns(["US"]),
+            use_llm=False,
+        )
+        assert "123-45-6789" not in anonymized
+        assert "AA123456C" in anonymized
+        assert any("SSN" in written for written in mapping.values())
+
+
+class TestRegexOnlyProfile:
+    def test_regex_only_profile_disables_llm(self) -> None:
+        cfg = get_config_for_profile(ConfigProfile.REGEX_ONLY)
+        assert cfg.use_llm is False
+        assert cfg.enable_cache is False
+        assert cfg.model_name == "none"
+        assert "EMAIL" in cfg.regex_patterns
+
+    def test_default_profiles_still_use_llm(self) -> None:
+        for profile in (
+            ConfigProfile.BEST_SPEED,
+            ConfigProfile.BEST_QUALITY,
+            ConfigProfile.BEST_COST,
+        ):
+            cfg = get_config_for_profile(profile)
+            assert cfg.use_llm is True
+            assert cfg.enable_cache is True

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1162,7 +1162,7 @@ requires-dist = [
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1212,7 +1212,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Plan item 16: run without a language model (air-gapped machines, cost, structured logs).

- `--no-llm` and `-p regex-only` skip `identify_entities_with_llm`
- Regex, checksums (`IBAN_LIKE`), `--countries`, operators, leftover scan, and linkage-risk still run
- No API key. `--verify-llm` is ignored so the process stays offline
- SDK: `anonymize_file(..., use_llm=False)` (default remains `True`)
- Names and identity clues are missed by design (documented in recipes / CLI)

Default hybrid behaviour is unchanged.

Packages: **0.15.0 → 0.16.0**.

This is plan item 16.

## Tests

`uv run ruff check .` and `uv run pytest` pass locally (174 tests).

`tests/test_regex_only.py` covers skip-LLM + still-mask-email, names left visible, checksums, operators, country filter, and `BEST_*` profiles still using the model.