### PR TITLE
feat: CSV as a first-class input (cell-level PII masking)

### DIFF
--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -437,6 +437,7 @@ def run(
                 mapping_passphrase=passphrase,
                 ephemeral_mapping=ephemeral_mapping,
                 entity_texts=entity_texts,
+                orig_to_written=final_mapping if is_tabular_path(str(file_path)) else None,
             )
             logging.info(f"Anonymization for {file_path} complete!")
             logging.info(f"Anonymized text saved into '{anonymized_output_file}'")
@@ -600,7 +601,11 @@ def verify(
         logging.error("%s", exc)
         sys.exit(1)
 
-    text = load_review_text(str(anonymized_file))
+    try:
+        text = load_review_text(str(anonymized_file))
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
     report = verify_anonymized_text(
         text,
         anonymized_file=str(anonymized_file),
@@ -637,7 +642,11 @@ def report_risk(
     ],
 ) -> None:
     """Score identity-clue clumps in a masked file. Does not change the file."""
-    text = load_review_text(str(anonymized_file))
+    try:
+        text = load_review_text(str(anonymized_file))
+    except ValueError as exc:
+        logging.error("%s", exc)
+        sys.exit(1)
     risk_report = assess_linkage_risk(text)
     risk_path = write_risk_report(risk_report, str(anonymized_file))
     logging.info(

--- a/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
+++ b/packages/pdf-anonymizer-cli/src/pdf_anonymizer_cli/cli.py
@@ -16,12 +16,13 @@ from pdf_anonymizer_core.conf import (
     operators_for_entity_profile,
     types_for_entity_profile,
 )
-from pdf_anonymizer_core.core import anonymize_file
+from pdf_anonymizer_core.core import anonymize_file, anonymize_tabular_file
 from pdf_anonymizer_core.gazetteers import load_phrase_list
 from pdf_anonymizer_core.llm_provider import configure_cache
 from pdf_anonymizer_core.mapping_crypto import resolve_mapping_passphrase
 from pdf_anonymizer_core.operators import parse_operator_specs
 from pdf_anonymizer_core.prompts import detailed, hipaa, simple
+from pdf_anonymizer_core.tables import is_tabular_path, load_review_text
 from pdf_anonymizer_core.utils import (
     consolidate_mapping,
     deanonymize_file,
@@ -372,26 +373,53 @@ def run(
     for i, file_path in enumerate(file_paths, 1):
         logging.info("=" * 40)
         logging.info(f"Processing file {i}/{len(file_paths)}: {file_path}")
-        full_anonymized_text, final_mapping = anonymize_file(
-            file_path=str(file_path),
-            characters_to_anonymize=config.chunk_size,
-            prompt_template=prompt_template,
-            model_name=config.model_name,
-            anonymized_entities=entities_to_anonymize,
-            chunk_overlap=config.chunk_overlap,
-            regex_patterns=config.regex_patterns,
-            max_retries=config.max_retries,
-            base_retry_delay=config.base_retry_delay,
-            max_retry_delay=config.max_retry_delay,
-            operators=operator_map or None,
-            fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
-            seed_mapping=seed_mapping,
-            keep_list=keep_phrases,
-            deny_list=deny_phrases,
-            use_llm=use_llm,
-        )
+        entity_texts = None
+        try:
+            if is_tabular_path(str(file_path)):
+                full_anonymized_text, final_mapping, entity_texts = (
+                    anonymize_tabular_file(
+                        file_path=str(file_path),
+                        characters_to_anonymize=config.chunk_size,
+                        prompt_template=prompt_template,
+                        model_name=config.model_name,
+                        anonymized_entities=entities_to_anonymize,
+                        chunk_overlap=config.chunk_overlap,
+                        regex_patterns=config.regex_patterns,
+                        max_retries=config.max_retries,
+                        base_retry_delay=config.base_retry_delay,
+                        max_retry_delay=config.max_retry_delay,
+                        operators=operator_map or None,
+                        fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
+                        seed_mapping=seed_mapping,
+                        keep_list=keep_phrases,
+                        deny_list=deny_phrases,
+                        use_llm=use_llm,
+                    )
+                )
+            else:
+                full_anonymized_text, final_mapping = anonymize_file(
+                    file_path=str(file_path),
+                    characters_to_anonymize=config.chunk_size,
+                    prompt_template=prompt_template,
+                    model_name=config.model_name,
+                    anonymized_entities=entities_to_anonymize,
+                    chunk_overlap=config.chunk_overlap,
+                    regex_patterns=config.regex_patterns,
+                    max_retries=config.max_retries,
+                    base_retry_delay=config.base_retry_delay,
+                    max_retry_delay=config.max_retry_delay,
+                    operators=operator_map or None,
+                    fake_secret=fake_secret or os.getenv("ANONYMIZER_FAKE_SECRET"),
+                    seed_mapping=seed_mapping,
+                    keep_list=keep_phrases,
+                    deny_list=deny_phrases,
+                    use_llm=use_llm,
+                )
+        except ValueError as exc:
+            logging.error("%s", exc)
+            sys.exit(1)
 
-        if full_anonymized_text and final_mapping:
+        if full_anonymized_text is not None and final_mapping is not None:
             seed_mapping = final_mapping
             # The mapping from anonymize_file is original -> placeholder.
             # We will standardize on placeholder -> original for subsequent steps.
@@ -408,6 +436,7 @@ def run(
                 str(file_path),
                 mapping_passphrase=passphrase,
                 ephemeral_mapping=ephemeral_mapping,
+                entity_texts=entity_texts,
             )
             logging.info(f"Anonymization for {file_path} complete!")
             logging.info(f"Anonymized text saved into '{anonymized_output_file}'")
@@ -571,7 +600,7 @@ def verify(
         logging.error("%s", exc)
         sys.exit(1)
 
-    text = anonymized_file.read_text(encoding="utf-8")
+    text = load_review_text(str(anonymized_file))
     report = verify_anonymized_text(
         text,
         anonymized_file=str(anonymized_file),
@@ -608,7 +637,7 @@ def report_risk(
     ],
 ) -> None:
     """Score identity-clue clumps in a masked file. Does not change the file."""
-    text = anonymized_file.read_text(encoding="utf-8")
+    text = load_review_text(str(anonymized_file))
     risk_report = assess_linkage_risk(text)
     risk_path = write_risk_report(risk_report, str(anonymized_file))
     logging.info(

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/conf.py
@@ -21,6 +21,10 @@ DEFAULT_PROMPT_NAME: str = "detailed"
 DEFAULT_MODEL_NAME: str = "gemini-2.5-flash"
 DEFAULT_CHUNK_OVERLAP: int = 1000
 
+# In-memory caps for CSV / Excel. Spreadsheets are not streamed.
+MAX_TABLE_BYTES: int = 50 * 1024 * 1024
+MAX_TABLE_CELLS: int = 500_000
+
 # Directories and file paths
 DEFAULT_ANONYMIZED_DIR: str = "data/anonymized"
 DEFAULT_MAPPINGS_DIR: str = "data/mappings"

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -16,7 +16,9 @@ and regex_ner docs for the full partitioned list).
 import logging
 import os
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from pdf_anonymizer_core.call_llm import identify_entities_with_llm
 from pdf_anonymizer_core.conf import DEFAULT_CHUNK_OVERLAP, DEFAULT_REGEX_PATTERNS
@@ -24,9 +26,329 @@ from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
 from pdf_anonymizer_core.gazetteers import apply_deny_list, apply_keep_list
 from pdf_anonymizer_core.operators import apply_operator, operator_for_type
 from pdf_anonymizer_core.regex_ner import extract_entities_via_regex
-from pdf_anonymizer_core.spans import replace_entities
+from pdf_anonymizer_core.spans import locate_spans, replace_entities
+from pdf_anonymizer_core.tables import (
+    REGEX_CELL_KINDS,
+    TableCell,
+    TableDocument,
+    TableSheet,
+    apply_mapping_to_table,
+    column_letter,
+    flatten_table_for_review,
+    header_labels,
+    is_rejected_spreadsheet,
+    is_tabular_path,
+    iter_cells,
+    load_table,
+    rejected_spreadsheet_error,
+)
 from pdf_anonymizer_core.utils import seed_placeholder_state
 from pdf_anonymizer_core.validators import LIKE_SUFFIX, parent_type, type_matches_filter
+
+_TYPE_PRIORITY = {
+    "CREDIT_CARD": 15,
+    "IBAN": 14,
+    "CRYPTO_BTC": 13,
+    "CRYPTO_ETH": 13,
+    "EMAIL": 12,
+    "SSN": 11,
+    "SSN_US": 11,
+    "SIN_CA": 11,
+    "NINO_GB": 11,
+    "INSEE_FR": 11,
+    "AADHAAR_IN": 11,
+    "RESIDENT_ID_CN": 11,
+    "EIN_US": 10,
+    "VAT_GB": 10,
+    "VAT_FR": 10,
+    "VAT_ES": 10,
+    "VAT_IT": 10,
+    "VAT_DE": 10,
+    "PAN_IN": 10,
+    "GSTIN_IN": 10,
+    "UNIFIED_SOCIAL_CREDIT_CODE_CN": 10,
+    "IPV4_ADDRESS": 9,
+    "IP_ADDRESS": 9,
+    "IPV6_ADDRESS": 9,
+    "MAC_ADDRESS": 8,
+    "VIN": 8,
+    "MEDICAL_NPI_US": 8,
+    "PASSPORT": 7,
+    "US_PASSPORT": 7,
+    "GB_PASSPORT": 7,
+    "DRIVERS_LICENSE_US": 6,
+    "DRIVERS_LICENSE_GB": 6,
+    "DRIVERS_LICENSE_FR": 6,
+    "DRIVERS_LICENSE_CA": 6,
+    "DATE_ISO": 5,
+    "CURRENCY_AMOUNT": 5,
+    "BIC_SWIFT": 5,
+    "PHONE": 4,
+    "URL": 4,
+    "INDIRECT": 4,
+    "PERSON": 3,
+    "ORGANIZATION": 2,
+    "LOCATION": 1,
+    "ADDRESS": 1,
+    "CUSTOM": 3,
+}
+
+
+def _type_priority(ent_type: str) -> int:
+    upper = ent_type.upper()
+    if upper.endswith(LIKE_SUFFIX):
+        return _TYPE_PRIORITY.get(parent_type(upper), 0) - 1
+    return _TYPE_PRIORITY.get(upper, 0)
+
+
+def collect_entities_from_chunks(
+    chunks: List[str],
+    *,
+    prompt_template: str,
+    model_name: str,
+    regex_patterns: Dict[str, str],
+    max_retries: int,
+    base_retry_delay: float,
+    max_retry_delay: float,
+    use_llm: bool,
+) -> List[dict]:
+    """Per chunk: extract_entities_via_regex then optional identify_entities_with_llm."""
+    collected_entities: List[dict] = []
+
+    if not use_llm:
+        logging.info(
+            "Regex-only / offline mode: skipping the language model. "
+            "Names and identity clues will be missed."
+        )
+
+    for i, text_page in enumerate(chunks):
+        logging.info(f"Identifying entities in part {i + 1}/{len(chunks)}...")
+        start_time = time.time()
+
+        regex_entities = extract_entities_via_regex(text_page, regex_patterns)
+
+        if use_llm:
+            llm_entities = identify_entities_with_llm(
+                text_page,
+                prompt_template,
+                model_name,
+                max_retries=max_retries,
+                base_retry_delay=base_retry_delay,
+                max_retry_delay=max_retry_delay,
+            )
+        else:
+            llm_entities = []
+
+        end_time = time.time()
+        duration = end_time - start_time
+        minutes = int(duration // 60)
+        seconds = int(duration % 60)
+        stage = "Regex + LLM" if use_llm else "Regex only"
+        logging.info(f"   NER stage duration ({stage}): {minutes}:{seconds:02d}")
+        logging.info(
+            f"   Found {len(regex_entities)} via Regex, {len(llm_entities)} via LLM."
+        )
+
+        collected_entities.extend(regex_entities)
+        collected_entities.extend(llm_entities)
+
+    return collected_entities
+
+
+def finalize_entities(
+    collected: List[dict],
+    full_text: str,
+    *,
+    anonymized_entities: Optional[List[str]],
+    keep_list: Optional[List[str]],
+    deny_list: Optional[List[str]],
+    apply_deny: bool = True,
+    seed_mapping: Optional[Dict[str, str]] = None,
+) -> List[dict]:
+    """Type-priority dedup, type filter, optional deny-list, keep-list, base-form merge."""
+    best_entities: Dict[str, dict] = {}
+    for ent in collected:
+        text = ent["text"]
+        ent_type = ent["type"].upper()
+        if text not in best_entities:
+            best_entities[text] = ent
+        else:
+            existing_type = best_entities[text]["type"].upper()
+            if _type_priority(ent_type) > _type_priority(existing_type):
+                best_entities[text] = ent
+
+    deduped_entities = list(best_entities.values())
+
+    entities_to_process = deduped_entities
+    if anonymized_entities:
+        entities_to_process = [
+            e
+            for e in deduped_entities
+            if type_matches_filter(e["type"], anonymized_entities)
+        ]
+
+    if apply_deny and deny_list:
+        entities_to_process = apply_deny_list(full_text, entities_to_process, deny_list)
+    if keep_list:
+        entities_to_process = apply_keep_list(entities_to_process, keep_list)
+
+    logging.info(
+        f"Collected {len(collected)} total entities. "
+        f"Deduplicated to {len(deduped_entities)}. "
+        f"Processing {len(entities_to_process)} filtered entities."
+    )
+
+    base_forms = {e.get("base_form") for e in entities_to_process if e.get("base_form")}
+    if seed_mapping:
+        base_forms.update(seed_mapping.keys())
+    sorted_base_forms = sorted(list(base_forms), key=len, reverse=True)
+    for entity in entities_to_process:
+        base_form = entity.get("base_form")
+        if not base_form:
+            continue
+        for potential_full_form in sorted_base_forms:
+            if base_form != potential_full_form and base_form in potential_full_form:
+                entity["base_form"] = potential_full_form
+                break
+
+    return entities_to_process
+
+
+def build_mapping(
+    entities: List[dict],
+    *,
+    seed_mapping: Optional[Dict[str, str]],
+    operators: Optional[Dict[str, str]],
+    fake_secret: Optional[str],
+) -> Dict[str, str]:
+    """seed_placeholder_state, PERSON_n / .v_n, apply_operator."""
+    if seed_mapping:
+        (
+            final_mapping,
+            base_entity_placeholders,
+            placeholder_counts,
+            variation_counters,
+        ) = seed_placeholder_state(seed_mapping)
+    else:
+        final_mapping = {}
+        placeholder_counts = {}
+        base_entity_placeholders = {}
+        variation_counters = {}
+
+    for entity in entities:
+        entity_text = entity["text"]
+        entity_type = entity["type"].upper()
+        base_form = entity.get("base_form") or entity_text
+
+        if entity_text in final_mapping:
+            continue
+
+        if base_form not in base_entity_placeholders:
+            current_count = placeholder_counts.get(entity_type, 0) + 1
+            placeholder_counts[entity_type] = current_count
+            main_placeholder = f"{entity_type}_{current_count}"
+            base_entity_placeholders[base_form] = main_placeholder
+            if base_form not in final_mapping:
+                final_mapping[base_form] = main_placeholder
+
+        main_placeholder = base_entity_placeholders[base_form]
+
+        if entity_text != base_form:
+            current_variation_count = variation_counters.get(main_placeholder, 0) + 1
+            variation_counters[main_placeholder] = current_variation_count
+            variation_placeholder = f"{main_placeholder}.v_{current_variation_count}"
+            final_mapping[entity_text] = variation_placeholder
+        else:
+            final_mapping[entity_text] = main_placeholder
+
+    if operators:
+        text_to_type: Dict[str, str] = {}
+        text_to_base: Dict[str, str] = {}
+        for entity in entities:
+            entity_text = entity["text"]
+            entity_type = entity["type"].upper()
+            base_form = entity.get("base_form") or entity_text
+            text_to_type[entity_text] = entity_type
+            text_to_base[entity_text] = base_form
+            if base_form not in text_to_type:
+                text_to_type[base_form] = entity_type
+                text_to_base[base_form] = base_form
+        seeded_originals = set(seed_mapping) if seed_mapping else set()
+        transformed: Dict[str, str] = {}
+        for original, placeholder in final_mapping.items():
+            if original in seeded_originals:
+                transformed[original] = placeholder
+                continue
+            entity_type = text_to_type.get(original, "ID")
+            transformed[original] = apply_operator(
+                original,
+                entity_type,
+                placeholder,
+                operator_for_type(entity_type, operators),
+                text_to_base.get(original, original),
+                fake_secret or "",
+            )
+        final_mapping = transformed
+
+    return final_mapping
+
+
+def anonymize_text_content(
+    full_text: str,
+    text_pages: List[str],
+    *,
+    prompt_template: str,
+    model_name: str,
+    anonymized_entities: Optional[List[str]] = None,
+    regex_patterns: Optional[Dict[str, str]] = None,
+    max_retries: int = 3,
+    base_retry_delay: float = 1.0,
+    max_retry_delay: float = 10.0,
+    operators: Optional[Dict[str, str]] = None,
+    fake_secret: Optional[str] = None,
+    seed_mapping: Optional[Dict[str, str]] = None,
+    keep_list: Optional[List[str]] = None,
+    deny_list: Optional[List[str]] = None,
+    use_llm: bool = True,
+) -> Tuple[str, Dict[str, str]]:
+    if regex_patterns is None:
+        regex_patterns = DEFAULT_REGEX_PATTERNS
+
+    collected_entities = collect_entities_from_chunks(
+        text_pages,
+        prompt_template=prompt_template,
+        model_name=model_name,
+        regex_patterns=regex_patterns,
+        max_retries=max_retries,
+        base_retry_delay=base_retry_delay,
+        max_retry_delay=max_retry_delay,
+        use_llm=use_llm,
+    )
+    entities_to_process = finalize_entities(
+        collected_entities,
+        full_text,
+        anonymized_entities=anonymized_entities,
+        keep_list=keep_list,
+        deny_list=deny_list,
+        apply_deny=True,
+        seed_mapping=seed_mapping,
+    )
+
+    final_mapping = build_mapping(
+        entities_to_process,
+        seed_mapping=seed_mapping,
+        operators=operators,
+        fake_secret=fake_secret,
+    )
+
+    anonymized_text = full_text
+    if entities_to_process:
+        anonymized_text = replace_entities(
+            full_text,
+            (entity["text"] for entity in entities_to_process),
+            final_mapping,
+        )
+    return anonymized_text, final_mapping
 
 
 def anonymize_file(
@@ -105,6 +427,29 @@ def anonymize_file(
     if regex_patterns is None:
         regex_patterns = DEFAULT_REGEX_PATTERNS
 
+    if is_rejected_spreadsheet(file_path):
+        raise rejected_spreadsheet_error(file_path)
+    if is_tabular_path(file_path):
+        review, mapping, _entity_texts = anonymize_tabular_file(
+            file_path,
+            characters_to_anonymize,
+            prompt_template,
+            model_name,
+            anonymized_entities=anonymized_entities,
+            chunk_overlap=chunk_overlap,
+            regex_patterns=regex_patterns,
+            max_retries=max_retries,
+            base_retry_delay=base_retry_delay,
+            max_retry_delay=max_retry_delay,
+            operators=operators,
+            fake_secret=fake_secret,
+            seed_mapping=seed_mapping,
+            keep_list=keep_list,
+            deny_list=deny_list,
+            use_llm=use_llm,
+        )
+        return review, mapping
+
     file_size = os.path.getsize(file_path)
     full_text, text_pages = load_and_extract_text_from_file(
         file_path, characters_to_anonymize, chunk_overlap
@@ -120,230 +465,217 @@ def anonymize_file(
     logging.info(f"  - File size: {file_size / 1024:.2f} KB")
     logging.info(f"  - Extracted text size: {extracted_text_size / 1024:.2f} KB")
 
-    # Accumulate all entities from all chunks
+    return anonymize_text_content(
+        full_text,
+        text_pages,
+        prompt_template=prompt_template,
+        model_name=model_name,
+        anonymized_entities=anonymized_entities,
+        regex_patterns=regex_patterns,
+        max_retries=max_retries,
+        base_retry_delay=base_retry_delay,
+        max_retry_delay=max_retry_delay,
+        operators=operators,
+        fake_secret=fake_secret,
+        seed_mapping=seed_mapping,
+        keep_list=keep_list,
+        deny_list=deny_list,
+        use_llm=use_llm,
+    )
+
+
+def _serialize_cell_line(sheet_name: str, cell: TableCell, label: str) -> str:
+    address = f"{sheet_name}!{column_letter(cell.column)}{cell.row}"
+    return f"[{address}] {label}: {cell.search_text}"
+
+
+def _searchable_row_cells(sheet: TableSheet, row: int) -> List[TableCell]:
+    return [
+        cell
+        for cell in sheet.cells
+        if cell.row == row and cell.search_text
+    ]
+
+
+def _cell_label(cell: TableCell, labels: Dict[int, str]) -> str:
+    return labels.get(cell.column, f"Col {column_letter(cell.column)}")
+
+
+def _split_oversized_row(
+    sheet_name: str,
+    row: int,
+    cells: List[TableCell],
+    labels: Dict[int, str],
+    characters_to_anonymize: int,
+    splitter: RecursiveCharacterTextSplitter,
+) -> List[str]:
+    blocks: List[str] = []
+    row_header = f"## Row {row}"
+    for cell in sorted(cells, key=lambda item: item.column):
+        label = _cell_label(cell, labels)
+        line = _serialize_cell_line(sheet_name, cell, label)
+        if len(line) <= characters_to_anonymize:
+            blocks.append(f"{row_header}\n{line}")
+            continue
+        chunks = splitter.split_text(cell.search_text)
+        total = max(len(chunks), 1)
+        address = f"{sheet_name}!{column_letter(cell.column)}{cell.row}"
+        if not chunks:
+            chunks = [cell.search_text]
+            total = 1
+        for index, chunk in enumerate(chunks, start=1):
+            blocks.append(
+                f"{row_header}\n[{address}] {label} (part {index}/{total}): {chunk}"
+            )
+    return blocks
+
+
+def build_llm_batches(doc: TableDocument, characters_to_anonymize: int) -> List[str]:
+    """Row-addressed LLM prompts. Overlap is not applied across rows."""
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=max(characters_to_anonymize, 1),
+        chunk_overlap=0,
+    )
+    batches: List[str] = []
+    for sheet in doc.sheets:
+        labels = header_labels(sheet)
+        units: List[str] = []
+        for row in range(1, sheet.max_row + 1):
+            cells = _searchable_row_cells(sheet, row)
+            if not cells:
+                continue
+            row_header = f"## Row {row}"
+            lines = [
+                _serialize_cell_line(sheet.name, cell, _cell_label(cell, labels))
+                for cell in sorted(cells, key=lambda item: item.column)
+            ]
+            row_block = row_header + "\n" + "\n".join(lines)
+            if len(row_block) > characters_to_anonymize:
+                units.extend(
+                    _split_oversized_row(
+                        sheet.name,
+                        row,
+                        cells,
+                        labels,
+                        characters_to_anonymize,
+                        splitter,
+                    )
+                )
+            else:
+                units.append(row_block)
+
+        current: List[str] = [f"# Sheet: {sheet.name}"]
+        current_len = len(current[0])
+        for unit in units:
+            extra = 1 + len(unit)
+            if current_len + extra > characters_to_anonymize and len(current) > 1:
+                batches.append("\n".join(current))
+                current = [f"# Sheet: {sheet.name}"]
+                current_len = len(current[0])
+            current.append(unit)
+            current_len += extra
+        if len(current) > 1:
+            batches.append("\n".join(current))
+    return batches
+
+
+def _llm_entity_in_cells(entity_text: str, cells: Iterable[TableCell]) -> bool:
+    if not entity_text:
+        return False
+    for cell in cells:
+        if cell.search_text and locate_spans(cell.search_text, [entity_text]):
+            return True
+    return False
+
+
+def anonymize_tabular_file(
+    file_path: str,
+    characters_to_anonymize: int,
+    prompt_template: str,
+    model_name: str,
+    anonymized_entities: Optional[List[str]] = None,
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+    regex_patterns: Optional[Dict[str, str]] = None,
+    max_retries: int = 3,
+    base_retry_delay: float = 1.0,
+    max_retry_delay: float = 10.0,
+    operators: Optional[Dict[str, str]] = None,
+    fake_secret: Optional[str] = None,
+    seed_mapping: Optional[Dict[str, str]] = None,
+    keep_list: Optional[List[str]] = None,
+    deny_list: Optional[List[str]] = None,
+    use_llm: bool = True,
+) -> Tuple[str, Dict[str, str], Tuple[str, ...]]:
+    """Anonymize a CSV/Excel file cell by cell.
+
+    Returns ``(review_flatten, orig→written, entity_texts)``. ``entity_texts``
+    is the same ``entity["text"]`` list the text engine passes to
+    ``replace_entities``.
+    """
+    del chunk_overlap  # row boundaries replace chunk overlap
+    if regex_patterns is None:
+        regex_patterns = DEFAULT_REGEX_PATTERNS
+
+    if is_rejected_spreadsheet(file_path):
+        raise rejected_spreadsheet_error(file_path)
+
+    doc = load_table(file_path)
+    cells = list(iter_cells(doc))
     collected_entities: List[dict] = []
 
-    if not use_llm:
-        logging.info(
-            "Regex-only / offline mode: skipping the language model. "
-            "Names and identity clues will be missed."
+    for cell in cells:
+        if not cell.search_text or cell.kind not in REGEX_CELL_KINDS:
+            continue
+        collected_entities.extend(
+            extract_entities_via_regex(cell.search_text, regex_patterns)
         )
 
-    for i, text_page in enumerate(text_pages):
-        logging.info(f"Identifying entities in part {i + 1}/{len(text_pages)}...")
-        start_time = time.time()
-
-        # 1st Stage: Regex NER
-        regex_entities = extract_entities_via_regex(text_page, regex_patterns)
-
-        # 2nd Stage: LLM NER (optional)
-        if use_llm:
+    if use_llm:
+        batches = build_llm_batches(doc, characters_to_anonymize)
+        for i, batch in enumerate(batches):
+            logging.info(f"Identifying entities in table batch {i + 1}/{len(batches)}...")
             llm_entities = identify_entities_with_llm(
-                text_page,
+                batch,
                 prompt_template,
                 model_name,
                 max_retries=max_retries,
                 base_retry_delay=base_retry_delay,
                 max_retry_delay=max_retry_delay,
             )
-        else:
-            llm_entities = []
-
-        end_time = time.time()
-        duration = end_time - start_time
-        minutes = int(duration // 60)
-        seconds = int(duration % 60)
-        stage = "Regex + LLM" if use_llm else "Regex only"
-        logging.info(f"   NER stage duration ({stage}): {minutes}:{seconds:02d}")
+            for entity in llm_entities:
+                text = entity.get("text") or ""
+                if _llm_entity_in_cells(text, cells):
+                    collected_entities.append(entity)
+    else:
         logging.info(
-            f"   Found {len(regex_entities)} via Regex, {len(llm_entities)} via LLM."
+            "Regex-only / offline mode: skipping the language model. "
+            "Names and identity clues will be missed."
         )
-
-        collected_entities.extend(regex_entities)
-        collected_entities.extend(llm_entities)
-
-    # Deduplicate entities by text, prioritizing more specific types if matched multiple times.
-    # Higher numbers win. Financial, government ID, crypto, and network identifiers
-    # receive elevated priority because they are high-risk and unambiguous.
-    type_priority = {
-        # Highest sensitivity / unambiguous structured PII (regex-first wins)
-        "CREDIT_CARD": 15,
-        "IBAN": 14,
-        "CRYPTO_BTC": 13,
-        "CRYPTO_ETH": 13,
-        "EMAIL": 12,
-        "SSN": 11,
-        "SSN_US": 11,
-        "SIN_CA": 11,
-        "NINO_GB": 11,
-        "INSEE_FR": 11,
-        "AADHAAR_IN": 11,
-        "RESIDENT_ID_CN": 11,
-        "EIN_US": 10,
-        "VAT_GB": 10,
-        "VAT_FR": 10,
-        "VAT_ES": 10,
-        "VAT_IT": 10,
-        "VAT_DE": 10,
-        "PAN_IN": 10,
-        "GSTIN_IN": 10,
-        "UNIFIED_SOCIAL_CREDIT_CODE_CN": 10,
-        "IPV4_ADDRESS": 9,
-        "IP_ADDRESS": 9,  # legacy
-        "IPV6_ADDRESS": 9,
-        "MAC_ADDRESS": 8,
-        "VIN": 8,
-        "MEDICAL_NPI_US": 8,
-        "PASSPORT": 7,
-        "US_PASSPORT": 7,
-        "GB_PASSPORT": 7,
-        "DRIVERS_LICENSE_US": 6,
-        "DRIVERS_LICENSE_GB": 6,
-        "DRIVERS_LICENSE_FR": 6,
-        "DRIVERS_LICENSE_CA": 6,
-        "DATE_ISO": 5,
-        "CURRENCY_AMOUNT": 5,
-        "BIC_SWIFT": 5,
-        "PHONE": 4,
-        "URL": 4,
-        # LLM-detected semantic types (lower than strong regex matches)
-        "INDIRECT": 4,  # nameless phrase that still identifies one person
-        "PERSON": 3,
-        "ORGANIZATION": 2,
-        "LOCATION": 1,
-        "ADDRESS": 1,
-        "CUSTOM": 3,
-    }
-
-    def _type_priority(ent_type: str) -> int:
-        upper = ent_type.upper()
-        if upper.endswith(LIKE_SUFFIX):
-            return type_priority.get(parent_type(upper), 0) - 1
-        return type_priority.get(upper, 0)
-
-    best_entities: Dict[str, dict] = {}
-    for ent in collected_entities:
-        text = ent["text"]
-        ent_type = ent["type"].upper()
-        if text not in best_entities:
-            best_entities[text] = ent
-        else:
-            existing_type = best_entities[text]["type"].upper()
-            if _type_priority(ent_type) > _type_priority(existing_type):
-                best_entities[text] = ent
-
-    deduped_entities = list(best_entities.values())
-
-    entities_to_process = deduped_entities
-    if anonymized_entities:
-        entities_to_process = [
-            e
-            for e in deduped_entities
-            if type_matches_filter(e["type"], anonymized_entities)
-        ]
 
     if deny_list:
-        entities_to_process = apply_deny_list(full_text, entities_to_process, deny_list)
-    if keep_list:
-        entities_to_process = apply_keep_list(entities_to_process, keep_list)
-
-    logging.info(
-        f"Collected {len(collected_entities)} total entities. "
-        f"Deduplicated to {len(deduped_entities)}. "
-        f"Processing {len(entities_to_process)} filtered entities."
-    )
-
-    # Consolidate base forms to handle variations like "John" vs "John Doe"
-    base_forms = {e.get("base_form") for e in entities_to_process if e.get("base_form")}
-    if seed_mapping:
-        base_forms.update(seed_mapping.keys())
-    sorted_base_forms = sorted(list(base_forms), key=len, reverse=True)
-    for entity in entities_to_process:
-        base_form = entity.get("base_form")
-        if not base_form:
-            continue
-        for potential_full_form in sorted_base_forms:
-            if base_form != potential_full_form and base_form in potential_full_form:
-                entity["base_form"] = potential_full_form
-                break
-
-    # Generate placeholders (optionally seeded from a previous document)
-    if seed_mapping:
-        (
-            final_mapping,
-            base_entity_placeholders,
-            placeholder_counts,
-            variation_counters,
-        ) = seed_placeholder_state(seed_mapping)
-    else:
-        final_mapping = {}
-        placeholder_counts = {}
-        base_entity_placeholders = {}
-        variation_counters = {}
-
-    for entity in entities_to_process:
-        entity_text = entity["text"]
-        entity_type = entity["type"].upper()
-        base_form = entity.get("base_form") or entity_text
-
-        if entity_text in final_mapping:
-            continue
-
-        if base_form not in base_entity_placeholders:
-            # New base entity, create main placeholder
-            current_count = placeholder_counts.get(entity_type, 0) + 1
-            placeholder_counts[entity_type] = current_count
-            main_placeholder = f"{entity_type}_{current_count}"
-            base_entity_placeholders[base_form] = main_placeholder
-            if base_form not in final_mapping:
-                final_mapping[base_form] = main_placeholder
-
-        main_placeholder = base_entity_placeholders[base_form]
-
-        if entity_text != base_form:
-            # It's a variation, create variation placeholder
-            current_variation_count = variation_counters.get(main_placeholder, 0) + 1
-            variation_counters[main_placeholder] = current_variation_count
-            variation_placeholder = f"{main_placeholder}.v_{current_variation_count}"
-            final_mapping[entity_text] = variation_placeholder
-        else:
-            final_mapping[entity_text] = main_placeholder
-
-    if operators:
-        text_to_type: Dict[str, str] = {}
-        text_to_base: Dict[str, str] = {}
-        for entity in entities_to_process:
-            entity_text = entity["text"]
-            entity_type = entity["type"].upper()
-            base_form = entity.get("base_form") or entity_text
-            text_to_type[entity_text] = entity_type
-            text_to_base[entity_text] = base_form
-            if base_form not in text_to_type:
-                text_to_type[base_form] = entity_type
-                text_to_base[base_form] = base_form
-        seeded_originals = set(seed_mapping) if seed_mapping else set()
-        transformed: Dict[str, str] = {}
-        for original, placeholder in final_mapping.items():
-            if original in seeded_originals:
-                transformed[original] = placeholder
+        for cell in cells:
+            if not cell.search_text:
                 continue
-            entity_type = text_to_type.get(original, "ID")
-            transformed[original] = apply_operator(
-                original,
-                entity_type,
-                placeholder,
-                operator_for_type(entity_type, operators),
-                text_to_base.get(original, original),
-                fake_secret or "",
-            )
-        final_mapping = transformed
+            collected_entities.extend(apply_deny_list(cell.search_text, [], deny_list))
 
-    anonymized_text = full_text
-    if entities_to_process:
-        anonymized_text = replace_entities(
-            full_text,
-            (entity["text"] for entity in entities_to_process),
-            final_mapping,
-        )
-
-    return anonymized_text, final_mapping
+    entities_to_process = finalize_entities(
+        collected_entities,
+        "",
+        anonymized_entities=anonymized_entities,
+        keep_list=keep_list,
+        deny_list=deny_list,
+        apply_deny=False,
+        seed_mapping=seed_mapping,
+    )
+    final_mapping = build_mapping(
+        entities_to_process,
+        seed_mapping=seed_mapping,
+        operators=operators,
+        fake_secret=fake_secret,
+    )
+    entity_texts = tuple(
+        entity["text"] for entity in entities_to_process if entity.get("text")
+    )
+    apply_mapping_to_table(doc, final_mapping, entity_texts)
+    review = flatten_table_for_review(doc, anonymized=True)
+    return review, final_mapping, entity_texts

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -382,7 +382,10 @@ def anonymize_file(
     exhausting context windows or memory.
 
     Args:
-        file_path: Path to the file to anonymize (.pdf, .md, or .txt).
+        file_path: Path to the file to anonymize (.pdf, .md, .txt, .csv, or
+            .xlsx). ``.xlsx`` requires the ``[excel]`` extra and raises
+            ``ValueError`` until it is installed. ``.xls`` / ``.xlsm`` /
+            ``.ods`` / ``.xlsb`` are rejected.
         characters_to_anonymize: Target character size of each chunk sent to the LLM.
         prompt_template: The full prompt template string (use one from
             pdf_anonymizer_core.prompts or supply your own).

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/load_and_extract.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/load_and_extract.py
@@ -19,6 +19,13 @@ from langchain_text_splitters import (
     RecursiveCharacterTextSplitter,
 )
 
+from pdf_anonymizer_core.tables import (
+    EXCEL_EXTRA_MESSAGE,
+    is_rejected_spreadsheet,
+    is_tabular_path,
+    rejected_spreadsheet_error,
+)
+
 
 def load_and_extract_text_from_pdf(
     file_path: str, characters_to_anonymize: int = 100000, chunk_overlap: int = 0
@@ -65,6 +72,15 @@ def load_and_extract_text_from_file(
     """
     path = Path(file_path)
     file_extension = path.suffix.lower()
+
+    if is_rejected_spreadsheet(file_path):
+        raise rejected_spreadsheet_error(file_path)
+    if is_tabular_path(file_path):
+        if file_extension == ".xlsx":
+            raise ValueError(EXCEL_EXTRA_MESSAGE)
+        raise ValueError(
+            f"{file_extension} files must be loaded as tables, not as plain text."
+        )
 
     try:
         if file_extension == ".pdf":

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -1,8 +1,4 @@
-"""Table I/O and per-cell apply for CSV (Excel I/O is behind the [excel] extra).
-
-Parse as a table, walk cells, write cells. Detection still uses the text
-engine; this module only loads, flattens for review, and writes cells.
-"""
+"""Table load/save, per-cell apply, and review flatten for CSV (Excel I/O is the [excel] extra)."""
 
 from __future__ import annotations
 
@@ -62,6 +58,8 @@ class TableSheet:
     max_column: int
     cells: list[TableCell] = field(default_factory=list)
     merge_ranges: list[str] = field(default_factory=list)
+    # Per-row field counts from the source (0 = a truly empty line).
+    row_widths: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -205,12 +203,14 @@ def load_csv(path: str) -> TableDocument:
     rows = list(csv.reader(io.StringIO(text), dialect))
     max_row = len(rows)
     max_column = max((len(row) for row in rows), default=0)
+    row_widths = [len(row) for row in rows]
 
     sheet = TableSheet(
         name="Sheet1",
         hidden=False,
         max_row=max_row,
         max_column=max_column,
+        row_widths=row_widths,
     )
     nonempty = 0
     for row_idx, row in enumerate(rows, start=1):
@@ -275,6 +275,12 @@ def _csv_write_value(cell: Optional[TableCell]) -> Any:
     return "" if cell.original is None else cell.original
 
 
+def _row_width(sheet: TableSheet, row: int) -> int:
+    if sheet.row_widths and 0 <= row - 1 < len(sheet.row_widths):
+        return sheet.row_widths[row - 1]
+    return sheet.max_column
+
+
 def save_csv(doc: TableDocument, path: str) -> None:
     sheet = doc.sheets[0] if doc.sheets else TableSheet(
         name="Sheet1", hidden=False, max_row=0, max_column=0
@@ -285,14 +291,15 @@ def save_csv(doc: TableDocument, path: str) -> None:
     with open(path, "w", encoding=encoding, newline="") as handle:
         writer = csv.writer(handle, **dialect)
         for row in range(1, sheet.max_row + 1):
+            width = _row_width(sheet, row)
+            if width == 0:
+                writer.writerow([])
+                continue
             values = [
                 _csv_write_value(lookup.get((row, col)))
-                for col in range(1, sheet.max_column + 1)
+                for col in range(1, width + 1)
             ]
-            if values and all(value == "" for value in values):
-                writer.writerow([])
-            else:
-                writer.writerow(values)
+            writer.writerow(values)
 
 
 def save_table(doc: TableDocument, path: str) -> None:

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -1,0 +1,402 @@
+"""Table I/O and per-cell apply for CSV (Excel I/O is behind the [excel] extra).
+
+Parse as a table, walk cells, write cells. Detection still uses the text
+engine; this module only loads, flattens for review, and writes cells.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from dataclasses import dataclass, field
+from datetime import date, datetime, time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Literal, Optional
+
+from pdf_anonymizer_core import conf
+from pdf_anonymizer_core.spans import replace_entities
+
+TABLE_SUFFIXES = frozenset({".csv", ".xlsx"})
+REJECT_SPREADSHEET_SUFFIXES = frozenset({".xls", ".xlsm", ".ods", ".xlsb"})
+
+EXCEL_EXTRA_MESSAGE = (
+    "Excel support requires the extra: "
+    'pip install "pdf-anonymizer-core[excel]"'
+)
+
+_REJECT_MESSAGES = {
+    ".xls": "Legacy .xls is not supported. Re-save as .xlsx or export CSV.",
+    ".xlsb": "Legacy .xls is not supported. Re-save as .xlsx or export CSV.",
+    ".xlsm": (
+        "Macro-enabled workbooks are not supported (macros can re-derive PII). "
+        "Re-save as .xlsx."
+    ),
+    ".ods": (
+        "OpenDocument spreadsheets are not supported in this version. "
+        "Export CSV or .xlsx."
+    ),
+}
+
+REGEX_CELL_KINDS = frozenset({"text", "formula"})
+CellKind = Literal["empty", "bool", "number", "date", "text", "formula"]
+
+
+@dataclass
+class TableCell:
+    sheet: str
+    row: int
+    column: int
+    search_text: str
+    original: Any
+    kind: CellKind
+    number_format: Optional[str] = None
+    formula: Optional[str] = None
+
+
+@dataclass
+class TableSheet:
+    name: str
+    hidden: bool
+    max_row: int
+    max_column: int
+    cells: list[TableCell] = field(default_factory=list)
+    merge_ranges: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TableDocument:
+    path: str
+    kind: Literal["csv", "xlsx"]
+    encoding: str = "utf-8"
+    had_bom: bool = False
+    dialect: dict = field(default_factory=dict)
+    sheets: list[TableSheet] = field(default_factory=list)
+
+
+def is_tabular_path(path: str) -> bool:
+    return Path(path).suffix.lower() in TABLE_SUFFIXES
+
+
+def is_rejected_spreadsheet(path: str) -> bool:
+    return Path(path).suffix.lower() in REJECT_SPREADSHEET_SUFFIXES
+
+
+def rejected_spreadsheet_error(path: str) -> ValueError:
+    suffix = Path(path).suffix.lower()
+    message = _REJECT_MESSAGES.get(
+        suffix, f"Spreadsheet format {suffix} is not supported."
+    )
+    return ValueError(message)
+
+
+def _require_openpyxl() -> None:
+    try:
+        import openpyxl  # noqa: F401
+    except ImportError as exc:
+        raise ValueError(EXCEL_EXTRA_MESSAGE) from exc
+
+
+def column_letter(column: int) -> str:
+    """1-based column index to Excel-style letters (1 → A, 27 → AA)."""
+    if column <= 0:
+        raise ValueError("column must be 1-based")
+    result = ""
+    n = column
+    while n:
+        n, rem = divmod(n - 1, 26)
+        result = chr(65 + rem) + result
+    return result
+
+
+def cell_to_search_text(value: Any) -> tuple[str, CellKind]:
+    """Serialize a native cell value for NER / deny-list / apply."""
+    if value is None or value == "":
+        return "", "empty"
+    if isinstance(value, bool):
+        return "", "bool"
+    if isinstance(value, int):
+        return str(value), "number"
+    if isinstance(value, float):
+        if value.is_integer() and abs(value) < 1e15:
+            return str(int(value)), "number"
+        return format(value, "g"), "number"
+    if isinstance(value, datetime):
+        if value.time() == time.min:
+            return value.date().isoformat(), "date"
+        return value.isoformat(sep=" ", timespec="seconds"), "date"
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value.isoformat(), "date"
+    return str(value), "text"
+
+
+def iter_cells(doc: TableDocument) -> Iterable[TableCell]:
+    for sheet in doc.sheets:
+        yield from sheet.cells
+
+
+def _cells_by_address(sheet: TableSheet) -> Dict[tuple[int, int], TableCell]:
+    return {(cell.row, cell.column): cell for cell in sheet.cells}
+
+
+def _dialect_kwargs(dialect: Any) -> dict:
+    return {
+        "delimiter": dialect.delimiter,
+        "quotechar": dialect.quotechar,
+        "escapechar": getattr(dialect, "escapechar", None),
+        "doublequote": dialect.doublequote,
+        "skipinitialspace": dialect.skipinitialspace,
+        "quoting": dialect.quoting,
+        "lineterminator": getattr(dialect, "lineterminator", "\r\n"),
+    }
+
+
+def _detect_lineterminator(text: str) -> str:
+    if "\r\n" in text:
+        return "\r\n"
+    if "\r" in text:
+        return "\r"
+    return "\n"
+
+
+def _decode_csv_bytes(raw: bytes) -> tuple[str, str, bool]:
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return raw.decode("utf-8-sig"), "utf-8-sig", True
+    for encoding in ("utf-8", "cp1252", "latin-1"):
+        try:
+            return raw.decode(encoding), encoding, False
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("latin-1"), "latin-1", False
+
+
+def _classify_csv_field(raw: str) -> tuple[str, CellKind]:
+    if raw == "":
+        return "", "empty"
+    # Only leading '=' is formula-like. '+' is an E.164 phone prefix.
+    if raw.startswith("="):
+        return raw, "formula"
+    return raw, "text"
+
+
+def _sniff_dialect(text: str) -> Any:
+    sample = text[:8192]
+    if not sample.strip():
+        return csv.excel
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=",;\t|")
+    except csv.Error:
+        return csv.excel
+
+
+def load_csv(path: str) -> TableDocument:
+    file_size = os.path.getsize(path)
+    if file_size > conf.MAX_TABLE_BYTES:
+        raise ValueError(
+            f"Table file exceeds the size limit of {conf.MAX_TABLE_BYTES} bytes."
+        )
+
+    raw = Path(path).read_bytes()
+    text, encoding, had_bom = _decode_csv_bytes(raw)
+    dialect = _sniff_dialect(text)
+    dialect_kwargs = _dialect_kwargs(dialect)
+    dialect_kwargs["lineterminator"] = _detect_lineterminator(text)
+
+    rows = list(csv.reader(io.StringIO(text), dialect))
+    max_row = len(rows)
+    max_column = max((len(row) for row in rows), default=0)
+
+    sheet = TableSheet(
+        name="Sheet1",
+        hidden=False,
+        max_row=max_row,
+        max_column=max_column,
+    )
+    nonempty = 0
+    for row_idx, row in enumerate(rows, start=1):
+        for col_idx, value in enumerate(row, start=1):
+            search_text, kind = _classify_csv_field(value)
+            if kind != "empty":
+                nonempty += 1
+                if nonempty > conf.MAX_TABLE_CELLS:
+                    raise ValueError(
+                        "Table has more than "
+                        f"{conf.MAX_TABLE_CELLS} non-empty cells."
+                    )
+            if kind == "empty":
+                continue
+            sheet.cells.append(
+                TableCell(
+                    sheet=sheet.name,
+                    row=row_idx,
+                    column=col_idx,
+                    search_text=search_text,
+                    original=value,
+                    kind=kind,
+                    formula=value if kind == "formula" else None,
+                )
+            )
+
+    return TableDocument(
+        path=path,
+        kind="csv",
+        encoding=encoding,
+        had_bom=had_bom,
+        dialect=dialect_kwargs,
+        sheets=[sheet],
+    )
+
+
+def load_table(path: str) -> TableDocument:
+    suffix = Path(path).suffix.lower()
+    if suffix in REJECT_SPREADSHEET_SUFFIXES:
+        raise rejected_spreadsheet_error(path)
+    if suffix == ".csv":
+        return load_csv(path)
+    if suffix == ".xlsx":
+        _require_openpyxl()
+        raise ValueError(EXCEL_EXTRA_MESSAGE)
+    raise ValueError(f"Not a supported table file: {path}")
+
+
+def _csv_write_value(cell: Optional[TableCell]) -> Any:
+    if cell is None or cell.kind == "empty":
+        return ""
+    if cell.kind == "bool":
+        return cell.original
+    if cell.kind == "formula":
+        # Neutralize so spreadsheet apps will not evaluate leftover formulas.
+        text = cell.search_text if cell.search_text != "" else str(cell.original)
+        if not str(text).startswith("'"):
+            return "'" + str(text)
+        return text
+    if cell.search_text != "":
+        return cell.search_text
+    return "" if cell.original is None else cell.original
+
+
+def save_csv(doc: TableDocument, path: str) -> None:
+    sheet = doc.sheets[0] if doc.sheets else TableSheet(
+        name="Sheet1", hidden=False, max_row=0, max_column=0
+    )
+    lookup = _cells_by_address(sheet)
+    encoding = "utf-8-sig" if doc.had_bom else "utf-8"
+    dialect = dict(doc.dialect) if doc.dialect else _dialect_kwargs(csv.excel)
+    with open(path, "w", encoding=encoding, newline="") as handle:
+        writer = csv.writer(handle, **dialect)
+        for row in range(1, sheet.max_row + 1):
+            values = [
+                _csv_write_value(lookup.get((row, col)))
+                for col in range(1, sheet.max_column + 1)
+            ]
+            if values and all(value == "" for value in values):
+                writer.writerow([])
+            else:
+                writer.writerow(values)
+
+
+def save_table(doc: TableDocument, path: str) -> None:
+    suffix = Path(path).suffix.lower()
+    if suffix == ".xlsx" or doc.kind == "xlsx":
+        _require_openpyxl()
+        raise ValueError(EXCEL_EXTRA_MESSAGE)
+    save_csv(doc, path)
+
+
+def apply_mapping_to_table(
+    doc: TableDocument,
+    orig_to_written: Dict[str, str],
+    entity_texts: Iterable[str],
+) -> TableDocument:
+    texts = [text for text in entity_texts if text]
+    if not texts:
+        return doc
+    for cell in iter_cells(doc):
+        if not cell.search_text:
+            continue
+        new = replace_entities(cell.search_text, texts, orig_to_written)
+        if new != cell.search_text:
+            cell.search_text = new
+    return doc
+
+
+def _flatten_cell_value(cell: Optional[TableCell], *, anonymized: bool) -> str:
+    if cell is None or cell.kind in {"empty", "bool"}:
+        return ""
+    if anonymized:
+        return cell.search_text
+    if cell.kind == "formula":
+        return str(cell.formula if cell.formula is not None else cell.original or "")
+    if cell.original is None:
+        return cell.search_text
+    return str(cell.original)
+
+
+def flatten_table_for_review(doc: TableDocument, *, anonymized: bool = True) -> str:
+    """Row-wise flatten for verify / risk / consolidate.
+
+    Blank line after the sheet header and after every row, including the last,
+    so risk windows do not glue a header or the next sheet onto a data row.
+    """
+    parts: list[str] = []
+    for sheet in doc.sheets:
+        parts.append(f"# Sheet: {sheet.name}")
+        parts.append("")
+        lookup = _cells_by_address(sheet)
+        for row in range(1, sheet.max_row + 1):
+            values = [
+                _flatten_cell_value(lookup.get((row, col)), anonymized=anonymized)
+                for col in range(1, sheet.max_column + 1)
+            ]
+            parts.append(" | ".join(values))
+            parts.append("")
+    if not parts:
+        return ""
+    return "\n".join(parts) + "\n"
+
+
+def load_review_text(path: str) -> str:
+    if is_rejected_spreadsheet(path):
+        raise rejected_spreadsheet_error(path)
+    if is_tabular_path(path):
+        return flatten_table_for_review(load_table(path), anonymized=True)
+    return Path(path).read_text(encoding="utf-8")
+
+
+def unneutralize_csv_equals(text: str) -> str:
+    if text.startswith("'") and text[1:].startswith("="):
+        return text[1:]
+    return text
+
+
+def header_labels(sheet: TableSheet) -> Dict[int, str]:
+    """First-row values when they look like unique headers; else Col A, Col B."""
+    lookup = _cells_by_address(sheet)
+    texts: list[str] = []
+    for col in range(1, sheet.max_column + 1):
+        cell = lookup.get((1, col))
+        if cell and cell.kind == "text" and cell.search_text.strip():
+            texts.append(cell.search_text.strip())
+        else:
+            texts.append("")
+    if texts and all(texts) and len({item.lower() for item in texts}) == len(texts):
+        return {index + 1: texts[index] for index in range(len(texts))}
+    return {
+        index: f"Col {column_letter(index)}"
+        for index in range(1, sheet.max_column + 1)
+    }
+
+
+def write_anonymized_table(
+    source_path: str,
+    dest_path: str,
+    orig_to_written: Dict[str, str],
+    entity_texts: Iterable[str],
+) -> None:
+    doc = load_table(source_path)
+    apply_mapping_to_table(doc, orig_to_written, entity_texts)
+    dest = Path(dest_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    save_table(doc, dest_path)
+
+

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 
 from pdf_anonymizer_core.conf import (
     DEFAULT_ANONYMIZED_DIR,
@@ -23,6 +23,15 @@ from pdf_anonymizer_core.mapping_crypto import (
     sha256_file,
 )
 from pdf_anonymizer_core.secure_io import write_private_json
+from pdf_anonymizer_core.tables import (
+    flatten_table_for_review,
+    is_tabular_path,
+    iter_cells,
+    load_table,
+    save_table,
+    unneutralize_csv_equals,
+    write_anonymized_table,
+)
 
 _PLACEHOLDER_PATTERN = re.compile(r"^[A-Z_]+_[0-9]+(?:\.v_[0-9]+)?$")
 
@@ -146,6 +155,7 @@ def save_results(
     mapping_passphrase: str | None = None,
     *,
     ephemeral_mapping: bool = False,
+    entity_texts: Optional[Iterable[str]] = None,
 ) -> tuple[str, str]:
     """
     Save the anonymized text and the mapping to files.
@@ -159,6 +169,8 @@ def save_results(
         ephemeral_mapping: If true, never write a mapping file. The second
             return value is an empty string. The caller already holds
             ``final_mapping`` in memory.
+        entity_texts: Detected ``entity["text"]`` values used to apply the
+            mapping. Required for table paths; ignored for text.
 
     Returns:
         tuple[str, str]: The paths to the anonymized text file and the mapping
@@ -180,8 +192,19 @@ def save_results(
     anonymized_output_file = (
         f"{anonymized_dir}/{file_stem}.anonymized{output_extension}"
     )
-    with open(anonymized_output_file, "w", encoding="utf-8") as f:
-        f.write(full_anonymized_text)
+    if is_tabular_path(file_path):
+        if entity_texts is None:
+            raise ValueError(
+                "save_results() on a table requires entity_texts= "
+                "(the same entity['text'] list the engine applied)."
+            )
+        orig_to_written = mapping_to_original_to_written(final_mapping)
+        write_anonymized_table(
+            file_path, anonymized_output_file, orig_to_written, entity_texts
+        )
+    else:
+        with open(anonymized_output_file, "w", encoding="utf-8") as f:
+            f.write(full_anonymized_text)
 
     if ephemeral_mapping:
         return anonymized_output_file, ""
@@ -204,6 +227,32 @@ def save_results(
         write_private_json(mapping_file, final_mapping)
 
     return anonymized_output_file, mapping_file
+
+
+def restore_placeholders_in_text(
+    text: str, placeholder_to_original: Dict[str, str]
+) -> tuple[str, set[str]]:
+    """Replace longest-first ``PLACEHOLDER`` / ``PLACEHOLDER.v_n`` tokens."""
+    used_placeholders: set[str] = set()
+    sorted_placeholders = sorted(
+        placeholder_to_original.keys(), key=len, reverse=True
+    )
+    if not sorted_placeholders:
+        return text, used_placeholders
+
+    pattern = re.compile(
+        r"\b("
+        + "|".join(re.escape(placeholder) for placeholder in sorted_placeholders)
+        + r")(?:\.v_\d+)?\b"
+    )
+
+    def replace_match(match: re.Match[str]) -> str:
+        full_match = match.group(0)
+        base_placeholder = match.group(1)
+        used_placeholders.add(full_match)
+        return placeholder_to_original[base_placeholder]
+
+    return pattern.sub(replace_match, text), used_placeholders
 
 
 def deanonymize_file(
@@ -238,9 +287,6 @@ def deanonymize_file(
             - unused_mappings: placeholders in the map that did not appear in text
             - not_found_mappings: placeholders seen in text but missing from the map
     """
-    with open(anonymized_file_path, "r", encoding="utf-8") as f:
-        anonymized_text = f.read()
-
     with open(mapping_file_path, "r", encoding="utf-8") as f:
         raw_mapping = json.load(f)
 
@@ -273,28 +319,30 @@ def deanonymize_file(
             if isinstance(placeholder, str):
                 placeholder_to_original.setdefault(placeholder, original)
 
-    deanonymized_text = anonymized_text
-    used_placeholders = set()  # track actual placeholders (including variations) found
-
-    # Replace placeholders by longest first to avoid partial overlaps
     sorted_placeholders = sorted(placeholder_to_original.keys(), key=len, reverse=True)
+    tabular = is_tabular_path(anonymized_file_path)
 
-    if sorted_placeholders:
-        # Match base and its variations: PERSON_1 and PERSON_1.v_1, PERSON_1.v_2, ...
-        # We use a single regex pass for all placeholders to avoid ReDoS and performance bottlenecks.
-        pattern = re.compile(
-            r"\b("
-            + "|".join(re.escape(p) for p in sorted_placeholders)
-            + r")(?:\.v_\d+)?\b"
+    if tabular:
+        doc = load_table(anonymized_file_path)
+        anonymized_text = flatten_table_for_review(doc, anonymized=True)
+        used_placeholders: set[str] = set()
+        for cell in iter_cells(doc):
+            if not cell.search_text:
+                continue
+            restored, cell_used = restore_placeholders_in_text(
+                cell.search_text, placeholder_to_original
+            )
+            used_placeholders |= cell_used
+            if doc.kind == "csv":
+                restored = unneutralize_csv_equals(restored)
+            if restored != cell.search_text:
+                cell.search_text = restored
+    else:
+        with open(anonymized_file_path, "r", encoding="utf-8") as f:
+            anonymized_text = f.read()
+        deanonymized_text, used_placeholders = restore_placeholders_in_text(
+            anonymized_text, placeholder_to_original
         )
-
-        def replace_match(match):
-            full_match = match.group(0)
-            base_placeholder = match.group(1)
-            used_placeholders.add(full_match)
-            return placeholder_to_original[base_placeholder]
-
-        deanonymized_text = pattern.sub(replace_match, deanonymized_text)
 
     # Gather stats
     all_placeholders_in_text = set(
@@ -317,8 +365,11 @@ def deanonymize_file(
     os.makedirs(stats_dir, exist_ok=True)
 
     deanonymized_file = f"{deanonymized_dir}/{file_stem}.deanonymized{output_extension}"
-    with open(deanonymized_file, "w", encoding="utf-8") as f:
-        f.write(deanonymized_text)
+    if tabular:
+        save_table(doc, deanonymized_file)
+    else:
+        with open(deanonymized_file, "w", encoding="utf-8") as f:
+            f.write(deanonymized_text)
 
     stats_file = f"{stats_dir}/{file_stem}.deanonymization_stat.json"
     stats = {

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
@@ -215,7 +215,7 @@ def save_results(
                 "Pass the engine original→written map as orig_to_written=."
             )
         write_anonymized_table(
-            file_path, anonymized_output_file, apply_map, entity_texts
+            file_path, anonymized_output_file, apply_map, texts
         )
     else:
         with open(anonymized_output_file, "w", encoding="utf-8") as f:

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/utils.py
@@ -156,13 +156,15 @@ def save_results(
     *,
     ephemeral_mapping: bool = False,
     entity_texts: Optional[Iterable[str]] = None,
+    orig_to_written: Optional[Dict[str, str]] = None,
 ) -> tuple[str, str]:
     """
     Save the anonymized text and the mapping to files.
 
     Args:
         full_anonymized_text (str): The anonymized text.
-        final_mapping (dict[str, str]): Mapping of original text -> placeholder.
+        final_mapping (dict[str, str]): Mapping written to the mapping file
+            (CLI invert: placeholder → original).
         file_path (str): The path to the original file.
         mapping_passphrase: If set, write ``*.mapping.json.enc`` (AES-256-GCM
             + Argon2id) instead of plaintext JSON.
@@ -171,6 +173,9 @@ def save_results(
             ``final_mapping`` in memory.
         entity_texts: Detected ``entity["text"]`` values used to apply the
             mapping. Required for table paths; ignored for text.
+        orig_to_written: Engine original → written map used to re-apply on
+            tables. Required for colliding mask/generalize/fake forms; when
+            omitted, ``mapping_to_original_to_written(final_mapping)`` is used.
 
     Returns:
         tuple[str, str]: The paths to the anonymized text file and the mapping
@@ -198,9 +203,19 @@ def save_results(
                 "save_results() on a table requires entity_texts= "
                 "(the same entity['text'] list the engine applied)."
             )
-        orig_to_written = mapping_to_original_to_written(final_mapping)
+        apply_map = (
+            orig_to_written
+            if orig_to_written is not None
+            else mapping_to_original_to_written(final_mapping)
+        )
+        texts = [text for text in entity_texts if text]
+        if texts and not any(text in apply_map for text in texts):
+            raise ValueError(
+                "save_results() entity_texts are not keys of orig_to_written. "
+                "Pass the engine original→written map as orig_to_written=."
+            )
         write_anonymized_table(
-            file_path, anonymized_output_file, orig_to_written, entity_texts
+            file_path, anonymized_output_file, apply_map, entity_texts
         )
     else:
         with open(anonymized_output_file, "w", encoding="utf-8") as f:

--- a/tests/data/tables/people.csv
+++ b/tests/data/tables/people.csv
@@ -1,0 +1,5 @@
+Name,Email,SSN,Phone,Notes,City,ID,Formula,Concat,Empty
+Jane Doe,jane@acme.com,123-45-6789,555-123-4567,Called John Smith about the Austin office.,"Austin, TX","00123",=A1,"=""Jane""&"" Doe""",
+
+John Smith,john@example.com,111-22-3333,+1-555-0100,"He said hello
+to the team.",Boston,,,,

--- a/tests/test_tables_csv.py
+++ b/tests/test_tables_csv.py
@@ -276,6 +276,52 @@ class TestSaveResultsInvert:
         assert leftover.read_text(encoding="utf-8")
         assert "Ada" not in leftover.read_text(encoding="utf-8").splitlines()[-1]
 
+    def test_colliding_mask_needs_engine_orig_map(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "emails.csv"
+        src.write_text("Email\nada@example.com\nalice@evil.com\n", encoding="utf-8")
+        review, mapping, entity_texts = anonymize_tabular_file(
+            str(src),
+            1000,
+            "unused",
+            "unused",
+            use_llm=False,
+            operators={"EMAIL": "mask"},
+        )
+        assert mapping["ada@example.com"] == mapping["alice@evil.com"]
+        invert = {written: original for original, written in mapping.items()}
+        assert len(invert) == 1
+        out, _mapping_path = save_results(
+            review,
+            invert,
+            str(src),
+            entity_texts=entity_texts,
+            orig_to_written=mapping,
+        )
+        rows = _grid(Path(out))
+        assert rows[1][0] == mapping["ada@example.com"]
+        assert rows[2][0] == mapping["alice@evil.com"]
+        assert "ada@example.com" not in rows[1] + rows[2]
+        assert "alice@evil.com" not in rows[1] + rows[2]
+
+        with pytest.raises(ValueError, match="orig_to_written"):
+            save_results(
+                review,
+                {"ada@example.com": mapping["ada@example.com"]},
+                str(src),
+                entity_texts=["ada@example.com"],
+            )
+
+
+class TestCsvRowWidths:
+    def test_ragged_rows_and_empty_field_rows_round_trip(self, tmp_path) -> None:
+        src = tmp_path / "ragged.csv"
+        src.write_bytes(b"a,b,c\n1,2\n\n,,,\n")
+        dest = tmp_path / "out.csv"
+        save_table(load_table(str(src)), str(dest))
+        assert _grid(dest) == _grid(src)
+        assert load_table(str(src)).sheets[0].row_widths == [3, 2, 0, 4]
+
 
 class TestVerifyAndRiskFlatten:
     def test_flatten_blank_lines_and_high_risk_row(self) -> None:
@@ -346,6 +392,19 @@ class TestVerifyAndRiskFlatten:
         report_result = runner.invoke(app, ["report", str(path)])
         assert report_result.exit_code == 0
         mocked.assert_called()
+
+    def test_verify_and_report_rejected_suffix_exits_without_traceback(
+        self, tmp_path
+    ) -> None:
+        path = tmp_path / "book.xls"
+        path.write_bytes(b"not-a-workbook")
+        runner = CliRunner()
+        verify_result = runner.invoke(app, ["verify", str(path)])
+        assert verify_result.exit_code == 1
+        assert "Traceback" not in (verify_result.output or "")
+        report_result = runner.invoke(app, ["report", str(path)])
+        assert report_result.exit_code == 1
+        assert "Traceback" not in (report_result.output or "")
 
 
 class TestRejectsAndLimits:

--- a/tests/test_tables_csv.py
+++ b/tests/test_tables_csv.py
@@ -276,6 +276,14 @@ class TestSaveResultsInvert:
         assert leftover.read_text(encoding="utf-8")
         assert "Ada" not in leftover.read_text(encoding="utf-8").splitlines()[-1]
 
+        out3, _mapping3 = save_results(
+            flatten,
+            {"PERSON_1": "Ada"},
+            str(src),
+            entity_texts=(t for t in ["Ada"]),
+        )
+        assert _grid(Path(out3))[1][0] == "PERSON_1"
+
     def test_colliding_mask_needs_engine_orig_map(self, tmp_path, monkeypatch) -> None:
         monkeypatch.chdir(tmp_path)
         src = tmp_path / "emails.csv"

--- a/tests/test_tables_csv.py
+++ b/tests/test_tables_csv.py
@@ -1,0 +1,455 @@
+"""CSV as a first-class input: cell-level masking, flatten, save, deanonymize."""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pdf_anonymizer_cli.cli import app
+from pdf_anonymizer_core.core import anonymize_file, anonymize_tabular_file
+from pdf_anonymizer_core.load_and_extract import load_and_extract_text_from_file
+from pdf_anonymizer_core.risk import assess_linkage_risk
+from pdf_anonymizer_core.tables import (
+    EXCEL_EXTRA_MESSAGE,
+    TABLE_SUFFIXES,
+    TableCell,
+    TableDocument,
+    TableSheet,
+    apply_mapping_to_table,
+    flatten_table_for_review,
+    load_review_text,
+    load_table,
+    save_table,
+)
+from pdf_anonymizer_core.utils import deanonymize_file, save_results
+from pdf_anonymizer_core.verify import verify_anonymized_text
+
+PEOPLE_CSV = Path(__file__).parent / "data" / "tables" / "people.csv"
+
+
+def _grid(path: Path) -> list[list[str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return [list(row) for row in csv.reader(handle)]
+
+
+def _anonymize_people(**kwargs):
+    defaults = dict(
+        characters_to_anonymize=1000,
+        prompt_template="unused",
+        model_name="unused",
+        use_llm=False,
+    )
+    defaults.update(kwargs)
+    return anonymize_tabular_file(str(PEOPLE_CSV), **defaults)
+
+
+class TestPeopleFixture:
+    def test_fixture_has_required_shapes(self) -> None:
+        doc = load_table(str(PEOPLE_CSV))
+        assert doc.kind == "csv"
+        sheet = doc.sheets[0]
+        assert sheet.name == "Sheet1"
+        assert sheet.max_row == 4
+        values = {
+            (cell.row, cell.column): cell
+            for cell in sheet.cells
+        }
+        assert values[(2, 7)].search_text == "00123"
+        assert values[(2, 7)].kind == "text"
+        assert values[(2, 8)].kind == "formula"
+        assert values[(2, 8)].search_text == "=A1"
+        assert values[(2, 9)].search_text == '="Jane"&" Doe"'
+        assert values[(2, 9)].kind == "formula"
+        assert values[(4, 4)].search_text == "+1-555-0100"
+        assert values[(4, 4)].kind == "text"
+        assert values[(2, 6)].search_text == "Austin, TX"
+        assert "\n" in values[(4, 5)].search_text
+        assert (3, 1) not in values
+
+
+class TestCsvRegexRoundTrip:
+    def test_masks_structured_pii_and_preserves_layout(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        review, mapping, entity_texts = _anonymize_people()
+        assert "jane@acme.com" not in review
+        assert "john@example.com" not in review
+        assert "123-45-6789" not in review
+        assert "111-22-3333" not in review
+        assert "EMAIL_1" in review
+        assert "SSN_US_1" in review
+        assert mapping["jane@acme.com"].startswith("EMAIL_")
+        assert mapping["123-45-6789"].startswith("SSN")
+
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(PEOPLE_CSV),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/people.anonymized.csv")
+        assert out.is_file()
+        rows = _grid(out)
+        assert rows[0][0] == "Name"
+        assert rows[0][1] == "Email"
+        assert rows[2] == [] or all(cell == "" for cell in rows[2])
+        assert rows[1][6] == "00123" or "_" in rows[1][6]
+        assert rows[1][5] == "Austin, TX"
+        assert "\n" in rows[3][4]
+        assert rows[1][1].startswith("EMAIL_")
+        assert rows[1][2].startswith("SSN")
+        assert not rows[1][1].endswith("@acme.com")
+
+    def test_formula_cells_are_prefixed_e164_is_not(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        review, mapping, entity_texts = _anonymize_people()
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(PEOPLE_CSV),
+            entity_texts=entity_texts,
+        )
+        rows = _grid(Path("data/anonymized/people.anonymized.csv"))
+        assert rows[1][7].startswith("'")
+        assert rows[1][7].startswith("'=")
+        assert rows[1][8].startswith("'=")
+        assert not rows[3][3].startswith("'")
+        assert "+1-555-0100" not in rows[3][3] or rows[3][3].startswith("PHONE")
+        assert rows[3][3] != "'+1-555-0100"
+
+
+class TestCsvDeanonymize:
+    def test_restores_source_including_equals(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        review, mapping, entity_texts = _anonymize_people()
+        anon_path, mapping_path = save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(PEOPLE_CSV),
+            entity_texts=entity_texts,
+        )
+        deanonymized_path, _stats = deanonymize_file(anon_path, mapping_path)
+        restored = _grid(Path(deanonymized_path))
+        source = _grid(PEOPLE_CSV)
+        assert restored == source
+        assert restored[1][7] == "=A1"
+        assert restored[1][8] == '="Jane"&" Doe"'
+        assert restored[3][3] == "+1-555-0100"
+
+
+class TestCsvDialect:
+    def test_semicolon_and_bom_are_preserved(self, tmp_path) -> None:
+        src = tmp_path / "eu.csv"
+        body = "Name;Email\nAda Lovelace;ada@example.com\n"
+        src.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+        doc = load_table(str(src))
+        assert doc.had_bom is True
+        assert doc.dialect["delimiter"] == ";"
+        dest = tmp_path / "eu.out.csv"
+        save_table(doc, str(dest))
+        raw = dest.read_bytes()
+        assert raw.startswith(b"\xef\xbb\xbf")
+        text = raw.decode("utf-8-sig")
+        assert ";" in text
+        assert "Ada Lovelace" in text
+
+
+class TestNotesAndLlmFilter:
+    def test_notes_column_replaces_inside_cell(self, mocker) -> None:
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "John Smith",
+                    "type": "PERSON",
+                    "base_form": "John Smith",
+                },
+                {"text": "Austin", "type": "LOCATION", "base_form": "Austin"},
+            ],
+        )
+        review, mapping, _texts = _anonymize_people(use_llm=True)
+        assert "John Smith" not in review
+        assert "Austin" not in review
+        assert mapping["John Smith"].startswith("PERSON_")
+        assert mapping["Austin"].startswith("LOCATION_")
+        assert "Called" in review
+        assert "office." in review
+
+    def test_llm_entities_need_locate_spans_in_a_cell(self, mocker, tmp_path) -> None:
+        src = tmp_path / "span.csv"
+        src.write_text("Name,Email\nAnne,ada@example.com\n", encoding="utf-8")
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "Jane Doe Email",
+                    "type": "PERSON",
+                    "base_form": "Jane Doe Email",
+                },
+                {"text": "Ann", "type": "PERSON", "base_form": "Ann"},
+            ],
+        )
+        _review, mapping, entity_texts = anonymize_tabular_file(
+            str(src), 1000, "unused", "unused", use_llm=True
+        )
+        assert "Jane Doe Email" not in mapping
+        assert "Ann" not in mapping
+        assert "Jane Doe Email" not in entity_texts
+        assert "Ann" not in entity_texts
+        assert "ada@example.com" in mapping
+
+
+class TestPerCellApply:
+    def test_mapping_does_not_cross_cells(self) -> None:
+        doc = TableDocument(
+            path="mem.csv",
+            kind="csv",
+            sheets=[
+                TableSheet(
+                    name="Sheet1",
+                    hidden=False,
+                    max_row=1,
+                    max_column=2,
+                    cells=[
+                        TableCell("Sheet1", 1, 1, "May", "May", "text"),
+                        TableCell("Sheet1", 1, 2, "Maybe later", "Maybe later", "text"),
+                    ],
+                )
+            ],
+        )
+        apply_mapping_to_table(doc, {"May": "DATE_1"}, ["May"])
+        cells = {(cell.column): cell.search_text for cell in doc.sheets[0].cells}
+        assert cells[1] == "DATE_1"
+        assert cells[2] == "Maybe later"
+
+    def test_seed_mapping_is_not_applied_without_ner_hit(self) -> None:
+        review, mapping, _texts = _anonymize_people(
+            seed_mapping={"Ada Lovelace": "PERSON_9"}
+        )
+        assert "Ada Lovelace" not in review
+        assert "PERSON_9" not in review
+        source = PEOPLE_CSV.read_text(encoding="utf-8")
+        assert "Ada Lovelace" not in source
+        jane_cell = [
+            cell.search_text
+            for cell in load_table(str(PEOPLE_CSV)).sheets[0].cells
+            if cell.search_text == "Jane Doe"
+        ]
+        assert jane_cell
+        assert "PERSON_9" not in mapping.get("Jane Doe", "")
+
+
+class TestSaveResultsInvert:
+    def test_cli_style_invert_masks_and_missing_entity_texts_raises(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "ada.csv"
+        src.write_text("Name\nAda\n", encoding="utf-8")
+        flatten = "# Sheet: Sheet1\n\nName\n\nPERSON_1\n\n"
+        out, _mapping = save_results(
+            flatten,
+            {"PERSON_1": "Ada"},
+            str(src),
+            entity_texts=["Ada"],
+        )
+        rows = _grid(Path(out))
+        assert rows[1][0] == "PERSON_1"
+
+        out2, _mapping2 = save_results(
+            flatten,
+            {"Ada": "PERSON_1"},
+            str(src),
+            entity_texts=["Ada"],
+        )
+        rows2 = _grid(Path(out2))
+        assert rows2[1][0] == "PERSON_1"
+
+        with pytest.raises(ValueError, match="entity_texts"):
+            save_results(flatten, {"PERSON_1": "Ada"}, str(src))
+        leftover = Path("data/anonymized/ada.anonymized.csv")
+        # The successful writes exist; a later missing-entity_texts call must
+        # not replace them with the cleartext source.
+        assert leftover.read_text(encoding="utf-8")
+        assert "Ada" not in leftover.read_text(encoding="utf-8").splitlines()[-1]
+
+
+class TestVerifyAndRiskFlatten:
+    def test_flatten_blank_lines_and_high_risk_row(self) -> None:
+        doc = TableDocument(
+            path="mem.csv",
+            kind="csv",
+            sheets=[
+                TableSheet(
+                    name="Employees",
+                    hidden=False,
+                    max_row=1,
+                    max_column=3,
+                    cells=[
+                        TableCell("Employees", 1, 1, "PERSON_1", "PERSON_1", "text"),
+                        TableCell(
+                            "Employees", 1, 2, "ORGANIZATION_1", "ORGANIZATION_1", "text"
+                        ),
+                        TableCell("Employees", 1, 3, "LOCATION_1", "LOCATION_1", "text"),
+                    ],
+                ),
+                TableSheet(
+                    name="Hidden",
+                    hidden=True,
+                    max_row=1,
+                    max_column=1,
+                    cells=[
+                        TableCell("Hidden", 1, 1, "PERSON_2", "PERSON_2", "text"),
+                    ],
+                ),
+            ],
+        )
+        flat = flatten_table_for_review(doc, anonymized=True)
+        assert flat.startswith("# Sheet: Employees\n\n")
+        assert "PERSON_1 | ORGANIZATION_1 | LOCATION_1\n\n# Sheet: Hidden\n\n" in flat
+        assert flat.endswith("PERSON_2\n\n")
+        report = assess_linkage_risk(flat)
+        assert report["overall"] == "high"
+
+    def test_load_review_text_is_flatten_not_raw_csv(self, tmp_path) -> None:
+        src = tmp_path / "quoted.csv"
+        src.write_text(
+            'Name,Notes\nAda,"hello, leftover@example.com"\n',
+            encoding="utf-8",
+        )
+        text = load_review_text(str(src))
+        assert "# Sheet: Sheet1" in text
+        assert " | " in text
+        assert "leftover@example.com" in text
+        assert not text.startswith("Name,Notes")
+        report = verify_anonymized_text(text)
+        assert any(hit["text"] == "leftover@example.com" for hit in report["regex_hits"])
+
+    def test_verify_and_report_cli_use_load_review_text(
+        self, tmp_path, monkeypatch, mocker
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / "note.anonymized.txt"
+        path.write_text("ok", encoding="utf-8")
+        mocked = mocker.patch(
+            "pdf_anonymizer_cli.cli.load_review_text",
+            return_value="hello leftover@example.com",
+        )
+        runner = CliRunner()
+        verify_result = runner.invoke(app, ["verify", str(path)])
+        assert verify_result.exit_code == 0
+        mocked.assert_called()
+        mocked.reset_mock()
+        report_result = runner.invoke(app, ["report", str(path)])
+        assert report_result.exit_code == 0
+        mocked.assert_called()
+
+
+class TestRejectsAndLimits:
+    def test_table_suffixes_include_xlsx(self) -> None:
+        assert ".csv" in TABLE_SUFFIXES
+        assert ".xlsx" in TABLE_SUFFIXES
+
+    def test_reject_legacy_spreadsheet_suffixes(self, tmp_path) -> None:
+        for name, match in (
+            ("book.xls", "Legacy .xls"),
+            ("book.xlsm", "Macro-enabled"),
+            ("book.ods", "OpenDocument"),
+            ("book.xlsb", "Legacy .xls"),
+        ):
+            path = tmp_path / name
+            path.write_bytes(b"not-a-workbook")
+            with pytest.raises(ValueError, match=match):
+                anonymize_file(str(path), 1000, "unused", "unused", use_llm=False)
+            with pytest.raises(ValueError, match=match):
+                load_and_extract_text_from_file(str(path))
+
+    def test_xlsx_requires_excel_extra(self, tmp_path, monkeypatch) -> None:
+        path = tmp_path / "roster.xlsx"
+        path.write_bytes(b"pk")
+        monkeypatch.setitem(sys.modules, "openpyxl", None)
+        with pytest.raises(ValueError, match=r'pdf-anonymizer-core\[excel\]'):
+            load_table(str(path))
+        assert EXCEL_EXTRA_MESSAGE in (
+            "Excel support requires the extra: "
+            'pip install "pdf-anonymizer-core[excel]"'
+        )
+
+    def test_cell_limit_raises(self, monkeypatch) -> None:
+        monkeypatch.setattr("pdf_anonymizer_core.conf.MAX_TABLE_CELLS", 2)
+        with pytest.raises(ValueError, match="cells"):
+            load_table(str(PEOPLE_CSV))
+
+    def test_byte_limit_raises(self, tmp_path, monkeypatch) -> None:
+        src = tmp_path / "big.csv"
+        src.write_text("a,b\n1,2\n", encoding="utf-8")
+        monkeypatch.setattr("pdf_anonymizer_core.conf.MAX_TABLE_BYTES", 4)
+        with pytest.raises(ValueError, match="bytes"):
+            load_table(str(src))
+
+
+class TestEmptyMappingStillWrites:
+    def test_pii_free_csv_is_written(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "plain.csv"
+        src.write_text("col_a,col_b\nhello,world\n", encoding="utf-8")
+        review, mapping, entity_texts = anonymize_tabular_file(
+            str(src), 1000, "unused", "unused", use_llm=False
+        )
+        assert mapping == {} or all(
+            not value.startswith("EMAIL_") for value in mapping.values()
+        )
+        out, mapping_path = save_results(
+            review, mapping, str(src), entity_texts=entity_texts
+        )
+        assert Path(out).is_file()
+        assert _grid(Path(out)) == _grid(src)
+        assert Path(mapping_path).is_file()
+
+
+class TestCrossFileMap:
+    def test_same_person_keeps_placeholder(self, mocker, tmp_path) -> None:
+        first = tmp_path / "a.csv"
+        first.write_text("Name\nJane Doe\n", encoding="utf-8")
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {"text": "Jane Doe", "type": "PERSON", "base_form": "Jane Doe"}
+            ],
+        )
+        mocker.patch(
+            "pdf_anonymizer_core.core.extract_entities_via_regex",
+            return_value=[],
+        )
+        _review, mapping, _texts = anonymize_tabular_file(
+            str(first), 1000, "unused", "unused", use_llm=True
+        )
+        assert mapping["Jane Doe"] == "PERSON_1"
+        mocker.patch("os.path.getsize", return_value=20)
+        mocker.patch(
+            "pdf_anonymizer_core.core.load_and_extract_text_from_file",
+            return_value=("Hello Jane Doe", ["Hello Jane Doe"]),
+        )
+        _text, second = anonymize_file(
+            "notes.md",
+            1000,
+            "unused",
+            "unused",
+            seed_mapping=mapping,
+            use_llm=True,
+        )
+        assert second["Jane Doe"] == "PERSON_1"
+
+
+class TestAnonymizeFileDispatch:
+    def test_csv_dispatch_returns_flatten(self) -> None:
+        review, mapping = anonymize_file(
+            str(PEOPLE_CSV), 1000, "unused", "unused", use_llm=False
+        )
+        assert review is not None
+        assert "# Sheet: Sheet1" in review
+        assert mapping is not None
+        assert "jane@acme.com" in mapping


### PR DESCRIPTION
## Summary
Adds CSV as a first-class input. Same cell-level job as PDF/MD/TXT: find names, emails, and similar in cells, write a real `.anonymized.csv` plus the usual mapping file.

This is **not** k-anonymity. No new database.

## Stack
1. **This PR** — CSV
2. Excel `.xlsx` via `openpyxl` extra
3. Docs + 0.17.0

Merge in order.

## What changed
- New `tables.py` (stdlib `csv`)
- Shared detect/map helpers extracted in `core.py` (existing `core.*` test patches stay valid)
- `save_results` / `deanonymize_file` / `verify` / `report` handle CSV
- `.xlsx` / `.xls` / `.xlsm` / ODS are rejected (Excel success path is PR 2)
- PII-free files now write output + empty mapping (`is not None` guard)

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest` (including `tests/test_tables_csv.py`)
- [ ] CI on this PR