### PR TITLE
feat: Excel .xlsx input via openpyxl extra

### DIFF
--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "pdf-anonymizer-core",
 ]
 
+[project.optional-dependencies]
+excel = ["pdf-anonymizer-core[excel]"]
+
 [project.urls]
 repository = "https://github.com/leo-gan/anonymizer"
 

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -22,6 +22,7 @@ huggingface = ["huggingface-hub"]
 openrouter = ["openai"]
 openai = ["openai"]
 anthropic = ["anthropic"]
+excel = ["openpyxl>=3.1"]
 
 [project.urls]
 repository = "https://github.com/leo-gan/anonymizer"

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -383,8 +383,8 @@ def anonymize_file(
 
     Args:
         file_path: Path to the file to anonymize (.pdf, .md, .txt, .csv, or
-            .xlsx). ``.xlsx`` requires the ``[excel]`` extra and raises
-            ``ValueError`` until it is installed. ``.xls`` / ``.xlsm`` /
+            .xlsx). ``.xlsx`` succeeds when the ``[excel]`` extra is installed
+            and raises ``ValueError`` if it is missing. ``.xls`` / ``.xlsm`` /
             ``.ods`` / ``.xlsb`` are rejected.
         characters_to_anonymize: Target character size of each chunk sent to the LLM.
         prompt_template: The full prompt template string (use one from

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -284,6 +284,14 @@ def _xlsx_cell_replaced(cell: TableCell) -> bool:
     return cell.search_text != initial
 
 
+def _xlsx_assign_value(excel_cell: Any, value: Any) -> None:
+    # openpyxl treats a leading '=' as a formula; force a string type so a
+    # cached "=A1" cannot re-derive a replaced name.
+    excel_cell.value = value
+    if isinstance(value, str) and value.startswith("="):
+        excel_cell.data_type = "s"
+
+
 def _open_xlsx_workbooks(path: str) -> tuple[Any, Any]:
     from openpyxl import load_workbook
 
@@ -318,8 +326,8 @@ def _cached_values_map(values_ws: Any) -> Dict[tuple[int, int], Any]:
 def load_xlsx(path: str) -> TableDocument:
     """Load .xlsx via openpyxl.
 
-    Comments, headers/footers, validation lists, charts, and pivot caches
-    are not walked and may retain identifiers.
+    Comments, headers/footers, validation lists, defined names, hyperlinks,
+    charts, and pivot caches are not walked and may retain identifiers.
     """
     _require_openpyxl()
     _check_table_file_size(path)
@@ -498,9 +506,9 @@ def save_xlsx(doc: TableDocument, path: str) -> None:
                     dropped += 1
                     recorded_formulas.add((row, col))
                 if _xlsx_cell_replaced(tcell):
-                    excel_cell.value = tcell.search_text
+                    _xlsx_assign_value(excel_cell, tcell.search_text)
                 elif tcell.kind == "formula":
-                    excel_cell.value = tcell.original
+                    _xlsx_assign_value(excel_cell, tcell.original)
             max_row = ws.max_row or 0
             max_column = ws.max_column or 0
             if max_row and max_column:
@@ -511,7 +519,7 @@ def save_xlsx(doc: TableDocument, path: str) -> None:
                         addr = (excel_cell.row, excel_cell.column)
                         if addr in recorded_formulas:
                             continue
-                        if _excel_cell_is_formula(excel_cell):
+                        if getattr(excel_cell, "data_type", None) == "f":
                             dropped += 1
                             excel_cell.value = None
         styled.save(path)

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -1,9 +1,10 @@
-"""Table load/save, per-cell apply, and review flatten for CSV (Excel I/O is the [excel] extra)."""
+"""Table load/save, per-cell apply, and review flatten for CSV and Excel."""
 
 from __future__ import annotations
 
 import csv
 import io
+import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -125,6 +126,8 @@ def cell_to_search_text(value: Any) -> tuple[str, CellKind]:
         return value.isoformat(sep=" ", timespec="seconds"), "date"
     if isinstance(value, date) and not isinstance(value, datetime):
         return value.isoformat(), "date"
+    if isinstance(value, time):
+        return value.isoformat(timespec="seconds"), "date"
     return str(value), "text"
 
 
@@ -247,6 +250,177 @@ def load_csv(path: str) -> TableDocument:
     )
 
 
+def _check_table_file_size(path: str) -> None:
+    file_size = os.path.getsize(path)
+    if file_size > conf.MAX_TABLE_BYTES:
+        raise ValueError(
+            f"Table file exceeds the size limit of {conf.MAX_TABLE_BYTES} bytes."
+        )
+
+
+def _styled_is_formula(value: Any, data_type: Optional[str] = None) -> bool:
+    if data_type == "f":
+        return True
+    if isinstance(value, str) and value.startswith("="):
+        return True
+    return type(value).__name__ in {"ArrayFormula", "DataTableFormula"}
+
+
+def _formula_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    text = getattr(value, "text", None)
+    if isinstance(text, str):
+        return text
+    return str(value) if value is not None else ""
+
+
+def _excel_cell_is_formula(cell: Any) -> bool:
+    return _styled_is_formula(cell.value, getattr(cell, "data_type", None))
+
+
+def _xlsx_cell_replaced(cell: TableCell) -> bool:
+    initial, _kind = cell_to_search_text(cell.original)
+    return cell.search_text != initial
+
+
+def _open_xlsx_workbooks(path: str) -> tuple[Any, Any]:
+    from openpyxl import load_workbook
+
+    styled = None
+    try:
+        # Two live workbooks + TableDocument is peak RAM; save_results reloads
+        # then save_xlsx opens styled again (five loads per run).
+        styled = load_workbook(path, data_only=False, read_only=False, keep_vba=False)
+        values = load_workbook(path, data_only=True, read_only=True, keep_vba=False)
+    except ValueError:
+        if styled is not None:
+            styled.close()
+        raise
+    except Exception as exc:
+        if styled is not None:
+            styled.close()
+        raise ValueError(f"Cannot open workbook {path}") from exc
+    return styled, values
+
+
+def _cached_values_map(values_ws: Any) -> Dict[tuple[int, int], Any]:
+    cached: Dict[tuple[int, int], Any] = {}
+    if values_ws is None:
+        return cached
+    for row in values_ws.iter_rows():
+        for cell in row:
+            if cell.value is not None and cell.value != "":
+                cached[(cell.row, cell.column)] = cell.value
+    return cached
+
+
+def load_xlsx(path: str) -> TableDocument:
+    """Load .xlsx via openpyxl.
+
+    Comments, headers/footers, validation lists, charts, and pivot caches
+    are not walked and may retain identifiers.
+    """
+    _require_openpyxl()
+    _check_table_file_size(path)
+
+    styled, values = _open_xlsx_workbooks(path)
+    missing_cache = 0
+    nonempty = 0
+    sheets: list[TableSheet] = []
+    try:
+        values_by_name = {ws.title: ws for ws in values.worksheets}
+        # worksheets skips chartsheets; includes hidden / veryHidden.
+        for ws in styled.worksheets:
+            cached = _cached_values_map(values_by_name.get(ws.title))
+            merge_ranges = [str(rng) for rng in ws.merged_cells.ranges]
+            merge_origins = {
+                (rng.min_row, rng.min_col) for rng in ws.merged_cells.ranges
+            }
+            max_row = ws.max_row or 0
+            max_column = ws.max_column or 0
+            sheet = TableSheet(
+                name=ws.title,
+                hidden=ws.sheet_state != "visible",
+                max_row=max_row,
+                max_column=max_column,
+                merge_ranges=merge_ranges,
+            )
+            if max_row and max_column:
+                for row in ws.iter_rows(
+                    min_row=1, max_row=max_row, max_col=max_column
+                ):
+                    for scell in row:
+                        addr = (scell.row, scell.column)
+                        styled_value = scell.value
+                        cached_value = cached.get(addr)
+                        is_formula = _styled_is_formula(
+                            styled_value, getattr(scell, "data_type", None)
+                        )
+                        present = (
+                            is_formula
+                            or (styled_value is not None and styled_value != "")
+                            or cached_value is not None
+                            or addr in merge_origins
+                        )
+                        if not present:
+                            continue
+                        if is_formula:
+                            if cached_value is None:
+                                missing_cache += 1
+                                search_text = ""
+                                original: Any = None
+                            else:
+                                search_text, _kind = cell_to_search_text(
+                                    cached_value
+                                )
+                                original = cached_value
+                            kind: CellKind = "formula"
+                            formula = _formula_text(styled_value)
+                        else:
+                            value = (
+                                styled_value
+                                if styled_value is not None and styled_value != ""
+                                else cached_value
+                            )
+                            search_text, kind = cell_to_search_text(value)
+                            original = value
+                            formula = None
+                        if kind != "empty":
+                            nonempty += 1
+                            if nonempty > conf.MAX_TABLE_CELLS:
+                                raise ValueError(
+                                    "Table has more than "
+                                    f"{conf.MAX_TABLE_CELLS} non-empty cells."
+                                )
+                        elif addr not in merge_origins:
+                            continue
+                        sheet.cells.append(
+                            TableCell(
+                                sheet=sheet.name,
+                                row=scell.row,
+                                column=scell.column,
+                                search_text=search_text,
+                                original=original,
+                                kind=kind,
+                                number_format=scell.number_format,
+                                formula=formula,
+                            )
+                        )
+            sheets.append(sheet)
+    finally:
+        styled.close()
+        values.close()
+
+    if missing_cache:
+        logging.warning(
+            "%s formula(s) had no cached value; treating as empty.",
+            missing_cache,
+        )
+
+    return TableDocument(path=path, kind="xlsx", sheets=sheets)
+
+
 def load_table(path: str) -> TableDocument:
     suffix = Path(path).suffix.lower()
     if suffix in REJECT_SPREADSHEET_SUFFIXES:
@@ -254,8 +428,7 @@ def load_table(path: str) -> TableDocument:
     if suffix == ".csv":
         return load_csv(path)
     if suffix == ".xlsx":
-        _require_openpyxl()
-        raise ValueError(EXCEL_EXTRA_MESSAGE)
+        return load_xlsx(path)
     raise ValueError(f"Not a supported table file: {path}")
 
 
@@ -302,11 +475,58 @@ def save_csv(doc: TableDocument, path: str) -> None:
             writer.writerow(values)
 
 
+def save_xlsx(doc: TableDocument, path: str) -> None:
+    _require_openpyxl()
+    from openpyxl import load_workbook
+
+    try:
+        styled = load_workbook(doc.path, data_only=False, read_only=False, keep_vba=False)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Cannot open workbook {doc.path}") from exc
+
+    dropped = 0
+    try:
+        cells_by_sheet = {sheet.name: _cells_by_address(sheet) for sheet in doc.sheets}
+        for ws in styled.worksheets:
+            lookup = cells_by_sheet.get(ws.title, {})
+            recorded_formulas: set[tuple[int, int]] = set()
+            for (row, col), tcell in lookup.items():
+                excel_cell = ws.cell(row=row, column=col)
+                if tcell.kind == "formula" or _excel_cell_is_formula(excel_cell):
+                    dropped += 1
+                    recorded_formulas.add((row, col))
+                if _xlsx_cell_replaced(tcell):
+                    excel_cell.value = tcell.search_text
+                elif tcell.kind == "formula":
+                    excel_cell.value = tcell.original
+            max_row = ws.max_row or 0
+            max_column = ws.max_column or 0
+            if max_row and max_column:
+                for row_cells in ws.iter_rows(
+                    min_row=1, max_row=max_row, max_col=max_column
+                ):
+                    for excel_cell in row_cells:
+                        addr = (excel_cell.row, excel_cell.column)
+                        if addr in recorded_formulas:
+                            continue
+                        if _excel_cell_is_formula(excel_cell):
+                            dropped += 1
+                            excel_cell.value = None
+        styled.save(path)
+    finally:
+        styled.close()
+
+    if dropped:
+        logging.info("Dropped %s formula(s); wrote cached values.", dropped)
+
+
 def save_table(doc: TableDocument, path: str) -> None:
     suffix = Path(path).suffix.lower()
     if suffix == ".xlsx" or doc.kind == "xlsx":
-        _require_openpyxl()
-        raise ValueError(EXCEL_EXTRA_MESSAGE)
+        save_xlsx(doc, path)
+        return
     save_csv(doc, path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
   "ruff",
   "pytest",
   "pytest-mock",
-  "pdf-anonymizer-core[huggingface,google,ollama,openrouter,openai,anthropic]",
+  "pdf-anonymizer-core[huggingface,google,ollama,openrouter,openai,anthropic,excel]",
   "pdf-anonymizer-cli",
   "mkdocs>=1.5.0",
   "mkdocs-material>=9.5.0",

--- a/tests/test_tables_xlsx.py
+++ b/tests/test_tables_xlsx.py
@@ -1,0 +1,329 @@
+"""Excel .xlsx input: load/save, types, formulas, hidden sheets."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook, load_workbook
+
+from pdf_anonymizer_core.core import anonymize_file, anonymize_tabular_file
+from pdf_anonymizer_core.tables import (
+    EXCEL_EXTRA_MESSAGE,
+    apply_mapping_to_table,
+    load_review_text,
+    load_table,
+    save_table,
+)
+from pdf_anonymizer_core.utils import save_results
+
+
+def _build_roster(path: Path) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Employees"
+    ws["A1"] = "Name"
+    ws["B1"] = "Email"
+    ws["C1"] = "Hired"
+    ws["D1"] = "EmployeeId"
+    ws["E1"] = "Active"
+    ws["F1"] = "Notes"
+    ws["G1"] = "Ref"
+    ws["A2"] = "Jane Doe"
+    ws["B2"] = "jane@acme.com"
+    ws["C2"] = datetime(2020, 1, 15)
+    ws["C2"].number_format = "YYYY-MM-DD"
+    ws["D2"] = 123456789
+    ws["D2"].number_format = "000-00-0000"
+    ws["E2"] = True
+    ws["F2"] = "Called John Smith about the Austin office."
+    ws["G2"] = "=A2"
+    ws.column_dimensions["A"].width = 24
+    ws.merge_cells("A3:B3")
+    ws["A3"] = "Merged block"
+
+    hidden = wb.create_sheet("Secrets")
+    hidden.sheet_state = "hidden"
+    hidden["A1"] = "Email"
+    hidden["A2"] = "hidden@acme.com"
+
+    wb.save(path)
+    wb.close()
+    return path
+
+
+def _cells(path: Path, sheet: str) -> dict[tuple[int, int], object]:
+    wb = load_workbook(path, data_only=False)
+    try:
+        ws = wb[sheet]
+        return {
+            (cell.row, cell.column): cell
+            for row in ws.iter_rows()
+            for cell in row
+            if cell.value is not None and cell.value != ""
+        }
+    finally:
+        wb.close()
+
+
+def _any_formula(path: Path) -> bool:
+    wb = load_workbook(path, data_only=False)
+    try:
+        for ws in wb.worksheets:
+            for row in ws.iter_rows():
+                for cell in row:
+                    if cell.data_type == "f":
+                        return True
+                    value = cell.value
+                    if isinstance(value, str) and value.startswith("="):
+                        return True
+                    if type(value).__name__ in {"ArrayFormula", "DataTableFormula"}:
+                        return True
+        return False
+    finally:
+        wb.close()
+
+
+def _anonymize_xlsx(path: Path, **kwargs):
+    defaults = dict(
+        characters_to_anonymize=1000,
+        prompt_template="unused",
+        model_name="unused",
+        use_llm=False,
+    )
+    defaults.update(kwargs)
+    return anonymize_tabular_file(str(path), **defaults)
+
+
+class TestXlsxLoad:
+    def test_multi_sheet_includes_hidden(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        assert doc.kind == "xlsx"
+        assert [sheet.name for sheet in doc.sheets] == ["Employees", "Secrets"]
+        assert doc.sheets[0].hidden is False
+        assert doc.sheets[1].hidden is True
+        lookup = {
+            (cell.sheet, cell.row, cell.column): cell
+            for sheet in doc.sheets
+            for cell in sheet.cells
+        }
+        assert lookup[("Employees", 2, 2)].kind == "text"
+        assert lookup[("Employees", 2, 2)].search_text == "jane@acme.com"
+        assert lookup[("Secrets", 2, 1)].search_text == "hidden@acme.com"
+        emp_id = lookup[("Employees", 2, 4)]
+        assert emp_id.kind == "number"
+        assert emp_id.search_text == "123456789"
+        assert emp_id.original == 123456789
+        hired = lookup[("Employees", 2, 3)]
+        assert hired.kind == "date"
+        assert hired.search_text == "2020-01-15"
+        active = lookup[("Employees", 2, 5)]
+        assert active.kind == "bool"
+        assert active.search_text == ""
+        formula = lookup[("Employees", 2, 7)]
+        assert formula.kind == "formula"
+        assert formula.formula == "=A2"
+
+    def test_display_format_is_not_search_text(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        emp_id = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.row == 2 and cell.column == 4
+        )
+        assert emp_id.search_text == "123456789"
+        assert "123-45-6789" not in emp_id.search_text
+        assert emp_id.number_format == "000-00-0000"
+
+    def test_missing_formula_cache_is_empty(self, tmp_path, caplog) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        with caplog.at_level("WARNING"):
+            doc = load_table(str(src))
+        formula = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.kind == "formula"
+        )
+        assert formula.search_text == ""
+        assert formula.original is None
+        assert "cached value" in caplog.text
+
+
+class TestXlsxAnonymize:
+    def test_multi_sheet_masks_and_preserves_structure(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        assert "jane@acme.com" not in review
+        assert "hidden@acme.com" not in review
+        assert "EMAIL_1" in review
+        assert "# Sheet: Employees" in review
+        assert "# Sheet: Secrets" in review
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        assert out.is_file()
+        wb = load_workbook(out)
+        try:
+            assert wb.sheetnames == ["Employees", "Secrets"]
+            assert wb["Secrets"].sheet_state == "hidden"
+            assert wb["Employees"].column_dimensions["A"].width == 24
+            assert "A3:B3" in wb["Employees"].merged_cells
+            assert wb["Employees"]["B2"].value.startswith("EMAIL_")
+            assert wb["Secrets"]["A2"].value.startswith("EMAIL_")
+        finally:
+            wb.close()
+
+    def test_untouched_types_stay_native_replaced_are_str(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        employees = _cells(out, "Employees")
+        email = employees[(2, 2)]
+        assert isinstance(email.value, str)
+        assert email.value.startswith("EMAIL_")
+        emp_id = employees[(2, 4)]
+        assert emp_id.value == 123456789
+        assert isinstance(emp_id.value, int)
+        active = employees[(2, 5)]
+        assert active.value is True
+        hired = employees[(2, 3)]
+        assert isinstance(hired.value, datetime)
+        assert hired.value == datetime(2020, 1, 15)
+
+    def test_numeric_id_skips_regex_without_llm(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        assert 123456789 not in mapping
+        assert "123456789" not in mapping
+        assert "US_PASSPORT_1" not in review
+        assert "DRIVERS_LICENSE_US_1" not in review
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        emp_id = _cells(Path("data/anonymized/roster.anonymized.xlsx"), "Employees")[
+            (2, 4)
+        ]
+        assert emp_id.value == 123456789
+
+    def test_formulas_never_emitted(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        assert _any_formula(out) is False
+        ref = load_workbook(out)["Employees"]["G2"].value
+        assert ref is None or (not isinstance(ref, str) or not ref.startswith("="))
+
+    def test_replaced_formula_writes_cached_string(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        formula = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.row == 2 and cell.column == 7
+        )
+        formula.original = "Jane Doe"
+        formula.search_text = "Jane Doe"
+        apply_mapping_to_table(doc, {"Jane Doe": "PERSON_1"}, ["Jane Doe"])
+        dest = tmp_path / "out.xlsx"
+        save_table(doc, str(dest))
+        assert _any_formula(dest) is False
+        assert load_workbook(dest)["Employees"]["G2"].value == "PERSON_1"
+        assert load_workbook(dest)["Employees"]["A2"].value == "PERSON_1"
+
+    def test_notes_free_text_is_replaced(self, tmp_path, mocker) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "John Smith",
+                    "type": "PERSON",
+                    "base_form": "John Smith",
+                },
+                {"text": "Austin", "type": "LOCATION", "base_form": "Austin"},
+            ],
+        )
+        review, mapping, entity_texts = _anonymize_xlsx(src, use_llm=True)
+        assert "John Smith" not in review
+        assert "Austin" not in review
+        assert mapping["John Smith"].startswith("PERSON_")
+        assert mapping["Austin"].startswith("LOCATION_")
+        assert "Called" in review
+        assert "office." in review
+        dest = tmp_path / "notes.xlsx"
+        doc = load_table(str(src))
+        apply_mapping_to_table(doc, mapping, entity_texts)
+        save_table(doc, str(dest))
+        notes = load_workbook(dest)["Employees"]["F2"].value
+        assert "John Smith" not in notes
+        assert "Austin" not in notes
+        assert "Called" in notes
+
+
+class TestXlsxDispatchAndReview:
+    def test_anonymize_file_dispatches_xlsx(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping = anonymize_file(
+            str(src), 1000, "unused", "unused", use_llm=False
+        )
+        assert review is not None
+        assert "# Sheet: Employees" in review
+        assert mapping is not None
+        assert "jane@acme.com" in mapping
+
+    def test_load_review_text_flattens_xlsx(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        text = load_review_text(str(src))
+        assert "# Sheet: Employees" in text
+        assert "# Sheet: Secrets" in text
+        assert "jane@acme.com" in text
+        assert " | " in text
+
+    def test_missing_openpyxl_raises_value_error(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        path = tmp_path / "roster.xlsx"
+        path.write_bytes(b"pk")
+        monkeypatch.setitem(sys.modules, "openpyxl", None)
+        with pytest.raises(ValueError, match=r'pdf-anonymizer-core\[excel\]'):
+            load_table(str(path))
+        assert EXCEL_EXTRA_MESSAGE == (
+            "Excel support requires the extra: "
+            'pip install "pdf-anonymizer-core[excel]"'
+        )

--- a/tests/test_tables_xlsx.py
+++ b/tests/test_tables_xlsx.py
@@ -79,10 +79,7 @@ def _any_formula(path: Path) -> bool:
                 for cell in row:
                     if cell.data_type == "f":
                         return True
-                    value = cell.value
-                    if isinstance(value, str) and value.startswith("="):
-                        return True
-                    if type(value).__name__ in {"ArrayFormula", "DataTableFormula"}:
+                    if type(cell.value).__name__ in {"ArrayFormula", "DataTableFormula"}:
                         return True
         return False
     finally:
@@ -265,6 +262,27 @@ class TestXlsxAnonymize:
         assert _any_formula(dest) is False
         assert load_workbook(dest)["Employees"]["G2"].value == "PERSON_1"
         assert load_workbook(dest)["Employees"]["A2"].value == "PERSON_1"
+
+    def test_cached_equals_string_is_not_written_as_formula(self, tmp_path) -> None:
+        src = tmp_path / "eq.xlsx"
+        wb = Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "=A1"
+        wb.save(src)
+        wb.close()
+        doc = load_table(str(src))
+        formula = next(
+            cell for cell in doc.sheets[0].cells if cell.row == 1 and cell.column == 2
+        )
+        formula.original = "=A1"
+        formula.search_text = "=A1"
+        dest = tmp_path / "out.xlsx"
+        save_table(doc, str(dest))
+        assert _any_formula(dest) is False
+        written = load_workbook(dest).active["B1"]
+        assert written.data_type != "f"
+        assert written.value == "=A1"
 
     def test_notes_free_text_is_replaced(self, tmp_path, mocker) -> None:
         src = _build_roster(tmp_path / "roster.xlsx")

--- a/uv.lock
+++ b/uv.lock
@@ -363,6 +363,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1040,6 +1049,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1153,12 +1174,19 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+excel = [
+    { name = "pdf-anonymizer-core", extra = ["excel"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "pdf-anonymizer-core", editable = "packages/pdf-anonymizer-core" },
+    { name = "pdf-anonymizer-core", extras = ["excel"], marker = "extra == 'excel'", editable = "packages/pdf-anonymizer-core" },
     { name = "rich" },
     { name = "typer" },
 ]
+provides-extras = ["excel"]
 
 [[package]]
 name = "pdf-anonymizer-core"
@@ -1176,6 +1204,9 @@ dependencies = [
 [package.optional-dependencies]
 anthropic = [
     { name = "anthropic" },
+]
+excel = [
+    { name = "openpyxl" },
 ]
 google = [
     { name = "google-genai" },
@@ -1205,10 +1236,11 @@ requires-dist = [
     { name = "ollama", marker = "extra == 'ollama'" },
     { name = "openai", marker = "extra == 'openai'" },
     { name = "openai", marker = "extra == 'openrouter'" },
+    { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "pymupdf4llm" },
     { name = "python-dotenv" },
 ]
-provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "anthropic"]
+provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "anthropic", "excel"]
 
 [[package]]
 name = "pdf-anonymizer-workspace"
@@ -1228,7 +1260,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pdf-anonymizer-cli" },
-    { name = "pdf-anonymizer-core", extra = ["anthropic", "google", "huggingface", "ollama", "openai", "openrouter"] },
+    { name = "pdf-anonymizer-core", extra = ["anthropic", "excel", "google", "huggingface", "ollama", "openai", "openrouter"] },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -1248,7 +1280,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
     { name = "pdf-anonymizer-cli", editable = "packages/pdf-anonymizer-cli" },
-    { name = "pdf-anonymizer-core", extras = ["huggingface", "google", "ollama", "openrouter", "openai", "anthropic"], editable = "packages/pdf-anonymizer-core" },
+    { name = "pdf-anonymizer-core", extras = ["huggingface", "google", "ollama", "openrouter", "openai", "anthropic", "excel"], editable = "packages/pdf-anonymizer-core" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },


### PR DESCRIPTION
## Summary
Adds `.xlsx` input behind the `[excel]` extra (`openpyxl`). Hidden sheets are included. Formulas are flattened to cached values and never written back.

Depends on #56 (CSV + shared table engine).

This is **not** k-anonymity.

## Stack
1. CSV — #56
2. **This PR** — Excel
3. Docs + 0.17.0

## What changed
- `load_xlsx` / `save_xlsx` (styled + `data_only` workbooks)
- `[excel]` extra on core; forwarded on CLI; included in the dev group
- Strings starting with `=` are stored as text so Excel will not re-evaluate them
- `tests/test_tables_xlsx.py`

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest` (CSV + xlsx)
- [ ] CI on this PR after #56