### PR TITLE
docs: CSV/Excel recipes and 0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This application anonymizes large PDF, Markdown, or Text files using a **hybrid 
 - **Large File Support**: Consistently anonymizes large files (tested up to 1GB).
 - **Multi-Provider & Cost-Effective**: Free to use with local [Ollama](https://ollama.com/) models. It also supports major providers like [OpenAI](https://openai.com/), [Anthropic](https://www.anthropic.com/), [Google](https://ai.google.com/), [Hugging Face](https://huggingface.co/), and [OpenRouter](https://openrouter.ai/).
 - **Reversible**: Supports deanonymization to recover original data when needed.
-- **Multi-Format**: Works with PDF, Markdown, and plain text files.
+- **Multi-Format**: Works with PDF, Markdown, plain text, CSV, and Excel files.
 
 ## 📖 Documentation
 

--- a/docs/internal/improvement-plan.md
+++ b/docs/internal/improvement-plan.md
@@ -23,6 +23,7 @@
 - [ ] 15. In-place PDF redaction
 - [x] 16. Regex-only / offline mode — done 2026-08-15, [PR #55](https://github.com/leo-gan/anonymizer/pull/55)
 - [x] 17. Secure mapping encryption workflow (Argon2id, AAD, 0600, ephemeral, wipe) — done 2026-08-15, [PR #54](https://github.com/leo-gan/anonymizer/pull/54)
+- [ ] 18. CSV / Excel as an input format (cell-level PII masking)
 
 ---
 
@@ -61,6 +62,7 @@ Known code facts to attach to:
 - `--no-llm` / `-p regex-only` skips the language model. Regex, checksums, operators, verify, and risk still run. Names and identity clues are missed.
 - `--keep-list` / `--deny-list` gazetteers. Keep wins if a phrase is on both lists.
 - `tests/eval/` scores mention-level and entity-level recall, split by direct vs quasi identifiers. `scripts/eval_tab.py` runs the fixture (regex stage if no predictions file). No product behavior change.
+- `.csv` / `.xlsx` take a table path (`tables.py`): per-cell regex on text/formula strings, row-addressed LLM batches, per-cell apply. Still pseudonymization, not *k*-anonymity (item 18).
 
 ---
 
@@ -395,11 +397,34 @@ Known code facts to attach to:
 
 ---
 
+### 18. CSV / Excel as an input format (cell-level PII masking)
+
+**Status:** planned
+
+**Technique:** same reversible pseudonymization as PDF/MD/TXT, on table cells.  
+**Why:** Users have rosters and exports. This is not k-anonymity.
+
+**Do**
+
+- Parse `.csv` (stdlib) and `.xlsx` (`openpyxl` extra) as tables.
+- Per-cell regex on text/formula strings only; row-addressed LLM batches; per-cell `replace_entities` with the same entity-text key list as the text engine.
+- Write `.anonymized.csv` / `.anonymized.xlsx` plus the existing mapping file.
+- Deanonymize / verify / report on the same formats.
+- Reject `.xls`, `.xlsm`, ODS. Drop Excel formulas (cached values only); neutralize CSV cells that start with `=` with a leading `'`; do not treat `+` / `@` as formulas.
+- Do **not** implement k-anonymity / ℓ-diversity / t-closeness or a new store.
+
+**Touches:** `tables.py`, `core.py` dispatch, `utils.save_results` / `deanonymize_file`,
+CLI `verify`/`report`, extras, tests, recipes / CLI usage / architecture.  
+**Prerequisite:** none.  
+**Version:** 0.17.0 when user-facing.
+
+---
+
 ## Out of scope
 
 | Technique | Why not as a core feature |
 |---|---|
-| *k*-anonymity / ℓ-diversity / *t*-closeness as a rewriter | Defined on tables of people, not narrative PDFs. Use (7) as a report. |
+| *k*-anonymity / ℓ-diversity / *t*-closeness as a rewriter | Defined on tables of people, not narrative PDFs. Use (7) as a report. Cell-level CSV/Excel masking (item 18) is still pseudonymization, not k-anonymity. |
 | Differential privacy on the document | Calibrated noise destroys prose; ε is meaningless on one contract. |
 | Mix / onion routing | Communication metadata, not document PII. |
 | Homomorphic encryption / MPC | Compute-on-encrypted-data; orthogonal to redaction. |

--- a/docs/project/api-reference.md
+++ b/docs/project/api-reference.md
@@ -13,6 +13,8 @@ It reflects the current public surface of `pdf-anonymizer-core`. The hand-writte
 
 ::: pdf_anonymizer_core.core.anonymize_file
 
+::: pdf_anonymizer_core.core.anonymize_tabular_file
+
 ::: pdf_anonymizer_core.utils.deanonymize_file
 
 ::: pdf_anonymizer_core.utils.consolidate_mapping
@@ -66,3 +68,17 @@ The package ships two ready-to-use prompt templates.
 ::: pdf_anonymizer_core.call_llm
 
 ::: pdf_anonymizer_core.load_and_extract
+
+---
+
+## Tables (CSV / Excel)
+
+::: pdf_anonymizer_core.tables.load_table
+
+::: pdf_anonymizer_core.tables.save_table
+
+::: pdf_anonymizer_core.tables.apply_mapping_to_table
+
+::: pdf_anonymizer_core.tables.flatten_table_for_review
+
+::: pdf_anonymizer_core.tables.load_review_text

--- a/docs/project/api-usage.md
+++ b/docs/project/api-usage.md
@@ -6,7 +6,7 @@ Developers can integrate `pdf-anonymizer-core` directly into their Python applic
 
 ## `anonymize_file`
 
-The `anonymize_file` function reads, extracts, chunks, and masks a file, returning the final anonymized string and the mapped PII dictionary.
+The `anonymize_file` function reads, extracts, chunks, and masks a file, returning the final anonymized string and the mapped PII dictionary. For `.csv` / `.xlsx` the string is a row-wise **review flatten** (used by verify/risk), not spreadsheet bytes.
 
 ### Import Signature
 ```python
@@ -14,7 +14,7 @@ from pdf_anonymizer_core.core import anonymize_file
 ```
 
 ### Parameters
-*   `file_path` (`str`): The absolute or relative path to the input document (supports `.pdf`, `.md`, `.txt`).
+*   `file_path` (`str`): The absolute or relative path to the input document (supports `.pdf`, `.md`, `.txt`, `.csv`, `.xlsx`). Excel needs the `[excel]` extra.
 *   `characters_to_anonymize` (`int`): Target character size of each chunk sent to the LLM.
 *   `prompt_template` (`str`): The prompt template string containing instructions for entity masking.
 *   `model_name` (`str`): The target model name (e.g. `"gemini-2.5-flash"`, `"google/gemini-2.5-pro"`, `"ollama/phi4-mini"`).
@@ -26,8 +26,45 @@ from pdf_anonymizer_core.core import anonymize_file
 *   `keep_list` / `deny_list` (`list[str]`, optional): Phrases to leave visible, or to force-hide as `CUSTOM_n`. Keep wins if both lists contain the same phrase.
 
 ### Returns
-*   `anonymized_text` (`str`): The fully processed text with placeholders in place of PII.
+*   `anonymized_text` (`str`): The fully processed text with placeholders in place of PII. For tables this is the review flatten, not a CSV/Excel dump.
 *   `mapping` (`dict[str, str]`): A dictionary mapping original entities to their assigned placeholders (or other written form).
+
+---
+
+## `anonymize_tabular_file`
+
+Use this when you need to **write** a `.csv` / `.xlsx` via `save_results`. It returns a third value, `entity_texts`, that `save_results` requires on the table path.
+
+### Import Signature
+```python
+from pdf_anonymizer_core.core import anonymize_tabular_file
+from pdf_anonymizer_core.utils import save_results
+```
+
+### Returns
+*   `review` (`str`): Row-wise flatten of the masked table.
+*   `mapping` (`dict[str, str]`): Original → written, same as `anonymize_file`.
+*   `entity_texts` (`tuple[str, ...]`): The same `entity["text"]` list the text engine passes to `replace_entities`.
+
+```python
+review, mapping, entity_texts = anonymize_tabular_file(
+    "people.csv",
+    characters_to_anonymize=100000,
+    prompt_template="",
+    model_name="",
+    use_llm=False,
+)
+# Pass the CLI invert (placeholder → original). Do not pass an orig→written
+# mask/hash/fake map (for example {addr: "****"}).
+save_results(
+    review,
+    {v: k for k, v in mapping.items()},
+    "people.csv",
+    entity_texts=entity_texts,
+)
+```
+
+`save_results` without `entity_texts` on a table raises. It does not write a cleartext copy.
 
 ---
 
@@ -41,7 +78,7 @@ from pdf_anonymizer_core.utils import deanonymize_file
 ```
 
 ### Parameters
-*   `anonymized_file_path` (`str`): Path to the markdown or text file that has placeholders.
+*   `anonymized_file_path` (`str`): Path to the markdown, text, CSV, or Excel file that has placeholders.
 *   `mapping_file_path` (`str`): Path to the JSON mapping file (plaintext or `*.mapping.json.enc`).
 *   `mapping_passphrase` (`str`, optional): Required when the mapping file is encrypted. Also used by the CLI via `--mapping-passphrase` / `ANONYMIZER_MAPPING_KEY`.
 *   `expected_source_sha256` (`str`, optional, keyword-only): When set, an encrypted mapping locked to a different source file is rejected.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -37,7 +37,7 @@ When you run `pdf-anonymizer run`, the system executes the following sequential 
 
 ```mermaid
 graph TD
-    File[Input File: PDF, MD, TXT] --> Ext[Text Extractor]
+    File[Input File: PDF, MD, TXT, CSV, XLSX] --> Ext[Text Extractor]
     Ext -->|Markdown Converter| RawMD[Raw Markdown String]
     RawMD --> Chunk[Text Chunking]
     Chunk --> Regex[RE2 regex + checksums]
@@ -57,6 +57,7 @@ graph TD
 ### Text Extraction & PDF Conversion
 *   Instead of traditional OCR or layout-unaware PDF parsing, the project uses `pymupdf4llm` to convert PDF files into clean, readable **Markdown**. This retains tables, headings, and lists in a structured text layout that LLMs can parse with higher accuracy.
 *   For Markdown and Text files, standard file reads are executed.
+*   CSV and Excel skip this loader. See [Table path](#table-path-csv--excel).
 
 ### Semantic Chunking
 *   Depending on the `--characters-to-anonymize` parameter (default `100,000` characters), the text is sliced into chunks:
@@ -128,6 +129,15 @@ To solve coreference problems (e.g. associating "Dr. Smith", "Smith", and "Dr. J
 ### TAB-style eval harness
 *   `tests/eval/` scores mention-level and entity-level recall, split by direct vs quasi identifiers.
 *   `scripts/eval_tab.py` runs the mini fixture. Tests and scripts only — no product change.
+
+### Table path (CSV / Excel)
+*   `.csv` and `.xlsx` never enter `load_and_extract_text_from_file`. `tables.load_table` walks cells; apply writes cells. The file is not flattened into one replacement buffer.
+*   **Regex** runs per-cell on `text` and formula-cached strings only. Number and date cells skip regex so employee IDs and quantities are not shredded.
+*   **LLM** sees row-addressed batches (`[Sheet!A2] Name: …`), including serialized number/date cells. A hit is kept only if `locate_spans` finds it in some cell.
+*   **Apply** is `replace_entities` on each cell's `search_text` with the same `entity["text"]` list the text engine uses.
+*   **Review flatten** (`v1 | v2 | …`, blank line after every row) is what `anonymize_file` returns for tables. `verify` and `report` score that flatten, not raw CSV bytes.
+*   Excel writes cached values only (no formulas). Charts, comments, headers/footers, validation lists, defined names, and hyperlinks are left as-is.
+*   This is still cell-level pseudonymization. It is not *k*-anonymity.
 
 ---
 

--- a/docs/project/cli-usage.md
+++ b/docs/project/cli-usage.md
@@ -14,7 +14,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] [OPTIONS]
 ```
 
 ### Arguments
-*   `FILE_PATH`: Space-separated list of paths to files (PDF, Markdown, or plain text).
+*   `FILE_PATH`: Space-separated list of paths to files (PDF, Markdown, plain text, CSV, or Excel `.xlsx`).
 
 ### Options
 
@@ -113,6 +113,7 @@ Score identity-clue clumps in an already-masked file. Does not change the file.
 
 ```bash
 pdf-anonymizer report data/anonymized/notes.anonymized.md
+pdf-anonymizer report data/anonymized/roster.anonymized.xlsx
 ```
 
 The report is `data/stats/<stem>.risk.json`. `run` already writes this unless you pass `--no-risk`.
@@ -125,6 +126,7 @@ Scan an already-masked file. This only writes a report. It does not change the f
 
 ```bash
 pdf-anonymizer verify data/anonymized/notes.anonymized.md
+pdf-anonymizer verify data/anonymized/people.anonymized.csv
 pdf-anonymizer verify data/anonymized/notes.anonymized.md --verify-llm -p best-quality
 ```
 
@@ -208,9 +210,9 @@ Files in the same `run` share one growing map, so the same person stays `PERSON_
 
 `run`, `verify`, `report`, and `deanonymize` write under conventional directories (created automatically):
 
-*   `data/anonymized/<stem>.anonymized.md` (or `.txt`)
+*   `data/anonymized/<stem>.anonymized.md` (or `.txt`, `.csv`, `.xlsx`)
 *   `data/mappings/<stem>.mapping.json` (or `*.mapping.json.enc` when a passphrase is set)
-*   `data/deanonymized/<stem>.deanonymized.md` (or `.txt`)
+*   `data/deanonymized/<stem>.deanonymized.md` (or `.txt`, `.csv`, `.xlsx`)
 *   `data/stats/<stem>.residual_pii.json` — leftovers found after masking (from `run` or `verify`)
 *   `data/stats/<stem>.risk.json` — identity-clue clumps (from `run` or `report`)
 *   `data/stats/<stem>.deanonymization_stat.json` — written by `deanonymize`
@@ -289,6 +291,14 @@ Replacement is by character interval, not a blind search-and-replace. The longer
 ### TAB-style eval harness
 
 `tests/eval/` and `scripts/eval_tab.py` score mention-level and entity-level recall, split by direct identifiers (email, SSN) versus quasi-identifiers (city, date). Tests and scripts only — the product does not change.
+
+### CSV and Excel as inputs (cell-level masking)
+
+`pdf-anonymizer run people.csv` and `pdf-anonymizer run roster.xlsx` (with the `[excel]` extra) walk cells and write a same-format spreadsheet plus the usual mapping. Detection and operators are the same engine as PDF/MD/TXT. This is cell-level pseudonymization, **not** *k*-anonymity. See [Anonymize a CSV or Excel roster](recipes.md#anonymize-a-csv-or-excel-roster).
+
+### PII-free files now write output + empty mapping
+
+A run that finds nothing still writes the output file and an empty mapping (`if full_anonymized_text is not None and final_mapping is not None`). That used to look like a failed run for every format, including PDF/MD/TXT.
 
 See [Recipes](recipes.md) for worked examples of each flag.
 

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -34,6 +34,7 @@ The project contains two decoupled Python packages inside `packages/`:
 Contains all the core engines, including:
 
 *   Text extraction from PDF, Markdown, and plain text formats.
+*   Table loaders for CSV (stdlib) and Excel (`.xlsx`, `[excel]` extra): per-cell regex, row-addressed LLM batches, per-cell apply.
 *   Hybrid detection: RE2 regex (with checksums / `TYPE_LIKE`) plus LLM NER.
 *   LLM router and adapters for various providers (Ollama, Gemini, OpenAI, etc.).
 *   Prompt templates (`simple`, `detailed`, `hipaa`) and identity-clue detection.
@@ -60,7 +61,7 @@ To dive deeper into the technical details, navigate through the following guides
 - **[CLI Reference](cli-usage.md)**: Explore the command-line arguments, options (including `--config-profile`), custom model strings, and usage examples.
 - **[SDK & API Usage](api-usage.md)**: Learn how to import PDF Anonymizer as a Python library in your own applications.
 - **[API Reference (auto)](api-reference.md)**: Living signature reference generated from source docstrings.
-- **[Recipes & Common Workflows](recipes.md)**: Practical end-to-end examples — local Ollama, locked maps, operators, HIPAA aid, keep/deny lists, leftover checks, eval harness, batching, caching, and more.
+- **[Recipes & Common Workflows](recipes.md)**: Practical end-to-end examples — local Ollama, locked maps, operators, HIPAA aid, keep/deny lists, leftover checks, CSV/Excel rosters, eval harness, batching, caching, and more.
 - **[Mapping encryption](mapping-security.md)**: Argon2id + AES-256-GCM envelopes, AAD, `0600` writes, ephemeral maps, and the tests that lock those in.
 - **[Troubleshooting](troubleshooting.md)**: Common errors (auth, rate limits, LLM parsing, empty results, large files) and solutions.
 - **[Architecture Design](architecture.md)**: Understand the data flow, prompt styling, LLM adapters, and file splitting mechanisms.

--- a/docs/project/installation.md
+++ b/docs/project/installation.md
@@ -20,7 +20,7 @@ The repository uses **`uv`**, a fast Python package installer and resolver. Ensu
     ```bash
     uv sync --group dev
     ```
-    This sync command will install the CLI, core library, and the dependencies for all supported LLM providers (`google`, `ollama`, `huggingface`, `openrouter`, `openai`, `anthropic`).
+    This sync command will install the CLI, core library, the Excel extra (`openpyxl`), and the dependencies for all supported LLM providers (`google`, `ollama`, `huggingface`, `openrouter`, `openai`, `anthropic`).
 
 3.  **Activate the virtual environment**:
     ```bash
@@ -36,13 +36,16 @@ If you are using `pdf-anonymizer-core` or `pdf-anonymizer-cli` in a separate ext
 To keep the installation footprint small, the core package uses **PEP 508 Extras** for specific LLM providers. Install only the providers you plan to use:
 
 ```bash
-# Base package only (no provider dependencies)
+# Base package only (no provider dependencies; CSV works here)
 pip install pdf-anonymizer-core
 
 # Install specific provider support
 pip install "pdf-anonymizer-core[google]"
 pip install "pdf-anonymizer-core[ollama]"
 pip install "pdf-anonymizer-core[openai,anthropic]"
+
+# Excel (.xlsx) input
+pip install "pdf-anonymizer-core[excel]"
 ```
 
 ### Available Extras
@@ -52,6 +55,7 @@ pip install "pdf-anonymizer-core[openai,anthropic]"
 *   `[openrouter]`: Installs client tools to query OpenRouter.
 *   `[openai]`: Installs the official OpenAI API SDK.
 *   `[anthropic]`: Installs the official Anthropic API SDK.
+*   `[excel]`: Installs `openpyxl` for `.xlsx` input. CSV uses the stdlib and needs no extra.
 
 ---
 

--- a/docs/project/recipes.md
+++ b/docs/project/recipes.md
@@ -207,6 +207,76 @@ For very large batch jobs you may want to:
 
 ---
 
+## Anonymize a CSV or Excel roster
+
+A roster, export, or clinic list is a table. The same engine walks **cells** and writes a same-format spreadsheet plus the usual mapping. This is the same reversible pseudonymization as a PDF. It is **not** *k*-anonymity: leftover columns are not crowd-hidden.
+
+CSV works with the base install. Excel (`.xlsx`) needs the extra:
+
+```bash
+pip install "pdf-anonymizer-core[excel]"
+# or
+pip install "pdf-anonymizer-cli[excel]"
+```
+
+**CLI**
+
+```bash
+pdf-anonymizer run people.csv
+pdf-anonymizer run roster.xlsx
+```
+
+That writes:
+
+- `data/anonymized/people.anonymized.csv` (or `roster.anonymized.xlsx`)
+- `data/mappings/people.mapping.json`
+
+```bash
+pdf-anonymizer deanonymize \
+  data/anonymized/people.anonymized.csv \
+  data/mappings/people.mapping.json
+
+pdf-anonymizer verify data/anonymized/people.anonymized.csv
+pdf-anonymizer report data/anonymized/roster.anonymized.xlsx
+```
+
+No new flags. `--no-llm`, `--operator`, `--keep-list` / `--deny-list`, `--mapping-in`, and the rest work the same way as on a PDF. Files in one `run` still share a growing map (`people.csv notes.md`).
+
+**Notes**
+
+- **Formulas are never written back.** Excel: cached values only. A leftover `=A1` would restore a replaced name. CSV: only a cell whose raw value starts with `=` is treated as formula-like and written with a leading `'`. Deanonymize strips that `'` when the remainder still starts with `=`. E.164 phones such as `+1-555-0100` are **not** formulas and are left untouched.
+- **Size / RAM.** Hard limits: 50 MiB on disk, 500,000 non-empty cells. Spreadsheets load in memory. Peak for a large `.xlsx` is two live workbooks plus the cell table (hundreds of MiB possible at the cap). This is **not** the 1 GB text-chunking path.
+- **Regex skips number and date cells.** Regex runs on text and formula-cached strings only. An undashed numeric ID stored as an Excel number is **missed** on `--no-llm`. Store the dashed form as text, use a deny-list, or keep the language model on. There is no “9-digit integer ⇒ SSN” rule.
+- **Stored value, not display format.** A numeric `123456789` with format `000-00-0000` is still seen as `123456789`.
+- **Leftover risk.** Charts, comments, headers/footers, data-validation lists, defined names, and hyperlinks are not rewritten. A chart series or a header can still show a name. Delete those before sharing, or accept the residual.
+- `.xls`, `.xlsm`, `.ods`, and `.xlsb` are rejected. Re-save as `.xlsx` or export CSV.
+
+**SDK (Python)**
+
+`anonymize_file("people.csv")` still returns a 2-tuple. The string is a row-wise **review flatten** (for verify/risk), not spreadsheet bytes. To write a real `.csv` / `.xlsx`, call `anonymize_tabular_file` and pass `entity_texts` into `save_results`:
+
+```python
+from pdf_anonymizer_core.core import anonymize_tabular_file
+from pdf_anonymizer_core.utils import save_results
+
+review, mapping, entity_texts = anonymize_tabular_file(
+    "people.csv",
+    characters_to_anonymize=100000,
+    prompt_template="",
+    model_name="",
+    use_llm=False,
+)
+# mapping is original → written. Pass the CLI invert into save_results.
+save_results(
+    review,
+    {v: k for k, v in mapping.items()},
+    "people.csv",
+    entity_texts=entity_texts,
+)
+```
+
+---
+
 ## Wrong-looking numbers are not treated as found
 
 A string of digits can *look* like a card number, a bank account, or a national ID and still be junk — a version number, an order id, or someone typing 1234-5678-9012-3456 as an example.
@@ -412,6 +482,8 @@ The CLI always enables caching according to the profile's `AppConfig`. Delete or
 ## Processing Very Large Documents
 
 PDF Anonymizer is designed for files up to ~1 GB thanks to streaming chunking.
+
+**Spreadsheets are in-memory.** CSV and Excel do **not** use this 1 GB streaming path. They are capped at 50 MiB / 500,000 non-empty cells and load the whole workbook. See [Anonymize a CSV or Excel roster](#anonymize-a-csv-or-excel-roster).
 
 **Practical tips**
 

--- a/docs/project/troubleshooting.md
+++ b/docs/project/troubleshooting.md
@@ -99,6 +99,37 @@ Common problems and how to resolve them.
   - Use `-p best-cost` (larger chunks).
   - Manually increase `--characters-to-anonymize` (e.g. 120000 or higher) when using a model with a large context window.
   - The tool uses Markdown-aware splitting for PDFs and `.md` files to preserve structure.
+  - CSV and Excel are **in-memory**. They are refused above 50 MiB or 500,000 non-empty cells. That is not the 1 GB text-chunking path.
+
+## Excel extra missing
+
+- **Symptom**: `Excel support requires the extra: pip install "pdf-anonymizer-core[excel]"`
+- **Fix**: `pip install "pdf-anonymizer-core[excel]"` or `pip install "pdf-anonymizer-cli[excel]"`. CSV does not need this extra.
+
+## Rejected spreadsheet formats
+
+- **Symptom**: `.xls`, `.xlsm`, `.ods`, or `.xlsb` is rejected with a convert-to-xlsx / export-CSV message.
+- **Fix**: Re-save as `.xlsx` or export CSV. Macro-enabled workbooks are not supported (macros can re-derive PII).
+
+## Formulas are dropped
+
+- **Symptom**: An Excel formula is gone; a CSV cell that started with `=` now starts with `'`.
+- **Fix**: That is intended. Excel writes cached values only so `=A1` cannot restore a replaced name. CSV prefixes `'` on cells whose raw value starts with `=`. `+1-555-0100` is a phone, not a formula, and is left untouched.
+
+## Charts, comments, and other leftovers
+
+- **Symptom**: A name still appears in a chart, comment, header/footer, data-validation list, defined name, or hyperlink.
+- **Fix**: Those surfaces are not walked. Delete charts and clear headers/comments before sharing, or accept the residual.
+
+## Undashed numeric IDs missed on `--no-llm`
+
+- **Symptom**: An Excel integer such as `123456789` is still the same integer after `--no-llm`.
+- **Fix**: Regex does not run on number or date cells (it would shred employee IDs and quantities). Store the dashed form as text, use a deny-list, or keep the language model on. There is no “9-digit integer ⇒ SSN” rule.
+
+## Stored value, not display format
+
+- **Symptom**: A numeric cell formatted as `000-00-0000` was not treated as a dashed SSN.
+- **Fix**: Detection uses the stored value (`123456789`), not Excel’s display format.
 
 ## Output Files Not Where Expected
 

--- a/packages/pdf-anonymizer-cli/README.md
+++ b/packages/pdf-anonymizer-cli/README.md
@@ -9,7 +9,7 @@ A command-line interface for anonymizing PDF, Markdown, and plain text files usi
 - **Large File Support**: Consistently anonymizes large files (tested up to 1GB).
 - **Multi-Provider & Cost-Effective**: Free to use with local [Ollama](https://ollama.com/) models. It also supports major providers like [OpenAI](https://openai.com/), [Anthropic](https://www.anthropic.com/), [Google](https://ai.google.com/), [Hugging Face](https://huggingface.co/), and [OpenRouter](https://openrouter.ai/).
 - **Reversible**: Supports deanonymization to recover original data when needed.
-- **Multi-Format**: Works with PDF, Markdown, and plain text files.
+- **Multi-Format**: Works with PDF, Markdown, plain text, CSV, and Excel files.
 
 
 ## Installation
@@ -22,6 +22,7 @@ Install the CLI with your favorite package manager. To use a specific LLM provid
 - **OpenRouter**: `pip install "pdf-anonymizer-cli[openrouter]"`
 - **OpenAI**: `pip install "pdf-anonymizer-cli[openai]"`
 - **Anthropic**: `pip install "pdf-anonymizer-cli[anthropic]"`
+- **Excel** (`.xlsx`): `pip install "pdf-anonymizer-cli[excel]"`
 
 You can also install multiple extras at once:
 
@@ -72,7 +73,7 @@ pdf-anonymizer run FILE_PATH [FILE_PATH ...] \
 ```
 
 **Arguments**:
-- `FILE_PATH`: Path to one or several PDF, Markdown, or text files for anonymization.
+- `FILE_PATH`: Path to one or several PDF, Markdown, text, CSV, or Excel (`.xlsx`) files for anonymization.
 
 **Options**:
 - `-p, --config-profile {best-quality|best-speed|best-cost|regex-only}`: The configuration profile to use. Profiles bundle sensible defaults for model, prompt, chunk size, overlap, and retries (default: `best-speed`). `regex-only` skips the language model. Individual flags (`--model-name`, `--prompt-name`, `--characters-to-anonymize`) act as overrides on top of the chosen profile.

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "pdf-anonymizer-core",
 ]
 
+[project.optional-dependencies]
+excel = ["pdf-anonymizer-core[excel]"]
+
 [project.urls]
 repository = "https://github.com/leo-gan/anonymizer"
 

--- a/packages/pdf-anonymizer-cli/pyproject.toml
+++ b/packages/pdf-anonymizer-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-cli"
-version = "0.16.0"
+version = "0.17.0"
 description = "CLI for a tool to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/README.md
+++ b/packages/pdf-anonymizer-core/README.md
@@ -2,6 +2,8 @@
 
 This package provides the core functionality for the PDF/Text anonymizer, including text extraction, LLM-driven anonymization, and deanonymization logic. It is used by `pdf-anonymizer-cli`.
 
+- **Multi-Format**: Works with PDF, Markdown, plain text, CSV, and Excel files.
+
 ## Installation
 
 Install the base package with your favorite package manager:
@@ -18,6 +20,7 @@ To use a specific LLM provider, you must install the corresponding extra. This h
 - **OpenRouter**: `pip install "pdf-anonymizer-core[openrouter]"`
 - **OpenAI**: `pip install "pdf-anonymizer-core[openai]"`
 - **Anthropic**: `pip install "pdf-anonymizer-core[anthropic]"`
+- **Excel** (`.xlsx`): `pip install "pdf-anonymizer-core[excel]"`
 
 You can also install multiple extras at once:
 

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-anonymizer-core"
-version = "0.16.0"
+version = "0.17.0"
 description = "A core library to anonymize PDF, Markdown, and plain text files using LLMs."
 authors = [{ name = "Leonid Ganeline", email = "leo.gan.57@gmail.com" }]
 license = { text = "MIT" }

--- a/packages/pdf-anonymizer-core/pyproject.toml
+++ b/packages/pdf-anonymizer-core/pyproject.toml
@@ -22,6 +22,7 @@ huggingface = ["huggingface-hub"]
 openrouter = ["openai"]
 openai = ["openai"]
 anthropic = ["anthropic"]
+excel = ["openpyxl>=3.1"]
 
 [project.urls]
 repository = "https://github.com/leo-gan/anonymizer"

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/core.py
@@ -383,8 +383,8 @@ def anonymize_file(
 
     Args:
         file_path: Path to the file to anonymize (.pdf, .md, .txt, .csv, or
-            .xlsx). ``.xlsx`` requires the ``[excel]`` extra and raises
-            ``ValueError`` until it is installed. ``.xls`` / ``.xlsm`` /
+            .xlsx). ``.xlsx`` succeeds when the ``[excel]`` extra is installed
+            and raises ``ValueError`` if it is missing. ``.xls`` / ``.xlsm`` /
             ``.ods`` / ``.xlsb`` are rejected.
         characters_to_anonymize: Target character size of each chunk sent to the LLM.
         prompt_template: The full prompt template string (use one from

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -430,6 +430,11 @@ def load_xlsx(path: str) -> TableDocument:
 
 
 def load_table(path: str) -> TableDocument:
+    """Load a ``.csv`` or ``.xlsx`` file as a ``TableDocument``.
+
+    Raises ``ValueError`` for rejected spreadsheet suffixes, a missing
+    ``[excel]`` extra, or a file over the size / cell cap.
+    """
     suffix = Path(path).suffix.lower()
     if suffix in REJECT_SPREADSHEET_SUFFIXES:
         raise rejected_spreadsheet_error(path)
@@ -531,6 +536,7 @@ def save_xlsx(doc: TableDocument, path: str) -> None:
 
 
 def save_table(doc: TableDocument, path: str) -> None:
+    """Write ``doc`` as ``.csv`` or ``.xlsx``. Excel formulas are not persisted."""
     suffix = Path(path).suffix.lower()
     if suffix == ".xlsx" or doc.kind == "xlsx":
         save_xlsx(doc, path)
@@ -543,6 +549,7 @@ def apply_mapping_to_table(
     orig_to_written: Dict[str, str],
     entity_texts: Iterable[str],
 ) -> TableDocument:
+    """Replace detected entity texts in each cell. Does not use mapping keys."""
     texts = [text for text in entity_texts if text]
     if not texts:
         return doc
@@ -591,6 +598,7 @@ def flatten_table_for_review(doc: TableDocument, *, anonymized: bool = True) -> 
 
 
 def load_review_text(path: str) -> str:
+    """Load text for ``verify`` / ``report``. Tables are flattened row-wise."""
     if is_rejected_spreadsheet(path):
         raise rejected_spreadsheet_error(path)
     if is_tabular_path(path):

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -284,6 +284,14 @@ def _xlsx_cell_replaced(cell: TableCell) -> bool:
     return cell.search_text != initial
 
 
+def _xlsx_assign_value(excel_cell: Any, value: Any) -> None:
+    # openpyxl treats a leading '=' as a formula; force a string type so a
+    # cached "=A1" cannot re-derive a replaced name.
+    excel_cell.value = value
+    if isinstance(value, str) and value.startswith("="):
+        excel_cell.data_type = "s"
+
+
 def _open_xlsx_workbooks(path: str) -> tuple[Any, Any]:
     from openpyxl import load_workbook
 
@@ -318,8 +326,8 @@ def _cached_values_map(values_ws: Any) -> Dict[tuple[int, int], Any]:
 def load_xlsx(path: str) -> TableDocument:
     """Load .xlsx via openpyxl.
 
-    Comments, headers/footers, validation lists, charts, and pivot caches
-    are not walked and may retain identifiers.
+    Comments, headers/footers, validation lists, defined names, hyperlinks,
+    charts, and pivot caches are not walked and may retain identifiers.
     """
     _require_openpyxl()
     _check_table_file_size(path)
@@ -498,9 +506,9 @@ def save_xlsx(doc: TableDocument, path: str) -> None:
                     dropped += 1
                     recorded_formulas.add((row, col))
                 if _xlsx_cell_replaced(tcell):
-                    excel_cell.value = tcell.search_text
+                    _xlsx_assign_value(excel_cell, tcell.search_text)
                 elif tcell.kind == "formula":
-                    excel_cell.value = tcell.original
+                    _xlsx_assign_value(excel_cell, tcell.original)
             max_row = ws.max_row or 0
             max_column = ws.max_column or 0
             if max_row and max_column:
@@ -511,7 +519,7 @@ def save_xlsx(doc: TableDocument, path: str) -> None:
                         addr = (excel_cell.row, excel_cell.column)
                         if addr in recorded_formulas:
                             continue
-                        if _excel_cell_is_formula(excel_cell):
+                        if getattr(excel_cell, "data_type", None) == "f":
                             dropped += 1
                             excel_cell.value = None
         styled.save(path)

--- a/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
+++ b/packages/pdf-anonymizer-core/src/pdf_anonymizer_core/tables.py
@@ -1,9 +1,10 @@
-"""Table load/save, per-cell apply, and review flatten for CSV (Excel I/O is the [excel] extra)."""
+"""Table load/save, per-cell apply, and review flatten for CSV and Excel."""
 
 from __future__ import annotations
 
 import csv
 import io
+import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -125,6 +126,8 @@ def cell_to_search_text(value: Any) -> tuple[str, CellKind]:
         return value.isoformat(sep=" ", timespec="seconds"), "date"
     if isinstance(value, date) and not isinstance(value, datetime):
         return value.isoformat(), "date"
+    if isinstance(value, time):
+        return value.isoformat(timespec="seconds"), "date"
     return str(value), "text"
 
 
@@ -247,6 +250,177 @@ def load_csv(path: str) -> TableDocument:
     )
 
 
+def _check_table_file_size(path: str) -> None:
+    file_size = os.path.getsize(path)
+    if file_size > conf.MAX_TABLE_BYTES:
+        raise ValueError(
+            f"Table file exceeds the size limit of {conf.MAX_TABLE_BYTES} bytes."
+        )
+
+
+def _styled_is_formula(value: Any, data_type: Optional[str] = None) -> bool:
+    if data_type == "f":
+        return True
+    if isinstance(value, str) and value.startswith("="):
+        return True
+    return type(value).__name__ in {"ArrayFormula", "DataTableFormula"}
+
+
+def _formula_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    text = getattr(value, "text", None)
+    if isinstance(text, str):
+        return text
+    return str(value) if value is not None else ""
+
+
+def _excel_cell_is_formula(cell: Any) -> bool:
+    return _styled_is_formula(cell.value, getattr(cell, "data_type", None))
+
+
+def _xlsx_cell_replaced(cell: TableCell) -> bool:
+    initial, _kind = cell_to_search_text(cell.original)
+    return cell.search_text != initial
+
+
+def _open_xlsx_workbooks(path: str) -> tuple[Any, Any]:
+    from openpyxl import load_workbook
+
+    styled = None
+    try:
+        # Two live workbooks + TableDocument is peak RAM; save_results reloads
+        # then save_xlsx opens styled again (five loads per run).
+        styled = load_workbook(path, data_only=False, read_only=False, keep_vba=False)
+        values = load_workbook(path, data_only=True, read_only=True, keep_vba=False)
+    except ValueError:
+        if styled is not None:
+            styled.close()
+        raise
+    except Exception as exc:
+        if styled is not None:
+            styled.close()
+        raise ValueError(f"Cannot open workbook {path}") from exc
+    return styled, values
+
+
+def _cached_values_map(values_ws: Any) -> Dict[tuple[int, int], Any]:
+    cached: Dict[tuple[int, int], Any] = {}
+    if values_ws is None:
+        return cached
+    for row in values_ws.iter_rows():
+        for cell in row:
+            if cell.value is not None and cell.value != "":
+                cached[(cell.row, cell.column)] = cell.value
+    return cached
+
+
+def load_xlsx(path: str) -> TableDocument:
+    """Load .xlsx via openpyxl.
+
+    Comments, headers/footers, validation lists, charts, and pivot caches
+    are not walked and may retain identifiers.
+    """
+    _require_openpyxl()
+    _check_table_file_size(path)
+
+    styled, values = _open_xlsx_workbooks(path)
+    missing_cache = 0
+    nonempty = 0
+    sheets: list[TableSheet] = []
+    try:
+        values_by_name = {ws.title: ws for ws in values.worksheets}
+        # worksheets skips chartsheets; includes hidden / veryHidden.
+        for ws in styled.worksheets:
+            cached = _cached_values_map(values_by_name.get(ws.title))
+            merge_ranges = [str(rng) for rng in ws.merged_cells.ranges]
+            merge_origins = {
+                (rng.min_row, rng.min_col) for rng in ws.merged_cells.ranges
+            }
+            max_row = ws.max_row or 0
+            max_column = ws.max_column or 0
+            sheet = TableSheet(
+                name=ws.title,
+                hidden=ws.sheet_state != "visible",
+                max_row=max_row,
+                max_column=max_column,
+                merge_ranges=merge_ranges,
+            )
+            if max_row and max_column:
+                for row in ws.iter_rows(
+                    min_row=1, max_row=max_row, max_col=max_column
+                ):
+                    for scell in row:
+                        addr = (scell.row, scell.column)
+                        styled_value = scell.value
+                        cached_value = cached.get(addr)
+                        is_formula = _styled_is_formula(
+                            styled_value, getattr(scell, "data_type", None)
+                        )
+                        present = (
+                            is_formula
+                            or (styled_value is not None and styled_value != "")
+                            or cached_value is not None
+                            or addr in merge_origins
+                        )
+                        if not present:
+                            continue
+                        if is_formula:
+                            if cached_value is None:
+                                missing_cache += 1
+                                search_text = ""
+                                original: Any = None
+                            else:
+                                search_text, _kind = cell_to_search_text(
+                                    cached_value
+                                )
+                                original = cached_value
+                            kind: CellKind = "formula"
+                            formula = _formula_text(styled_value)
+                        else:
+                            value = (
+                                styled_value
+                                if styled_value is not None and styled_value != ""
+                                else cached_value
+                            )
+                            search_text, kind = cell_to_search_text(value)
+                            original = value
+                            formula = None
+                        if kind != "empty":
+                            nonempty += 1
+                            if nonempty > conf.MAX_TABLE_CELLS:
+                                raise ValueError(
+                                    "Table has more than "
+                                    f"{conf.MAX_TABLE_CELLS} non-empty cells."
+                                )
+                        elif addr not in merge_origins:
+                            continue
+                        sheet.cells.append(
+                            TableCell(
+                                sheet=sheet.name,
+                                row=scell.row,
+                                column=scell.column,
+                                search_text=search_text,
+                                original=original,
+                                kind=kind,
+                                number_format=scell.number_format,
+                                formula=formula,
+                            )
+                        )
+            sheets.append(sheet)
+    finally:
+        styled.close()
+        values.close()
+
+    if missing_cache:
+        logging.warning(
+            "%s formula(s) had no cached value; treating as empty.",
+            missing_cache,
+        )
+
+    return TableDocument(path=path, kind="xlsx", sheets=sheets)
+
+
 def load_table(path: str) -> TableDocument:
     suffix = Path(path).suffix.lower()
     if suffix in REJECT_SPREADSHEET_SUFFIXES:
@@ -254,8 +428,7 @@ def load_table(path: str) -> TableDocument:
     if suffix == ".csv":
         return load_csv(path)
     if suffix == ".xlsx":
-        _require_openpyxl()
-        raise ValueError(EXCEL_EXTRA_MESSAGE)
+        return load_xlsx(path)
     raise ValueError(f"Not a supported table file: {path}")
 
 
@@ -302,11 +475,58 @@ def save_csv(doc: TableDocument, path: str) -> None:
             writer.writerow(values)
 
 
+def save_xlsx(doc: TableDocument, path: str) -> None:
+    _require_openpyxl()
+    from openpyxl import load_workbook
+
+    try:
+        styled = load_workbook(doc.path, data_only=False, read_only=False, keep_vba=False)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Cannot open workbook {doc.path}") from exc
+
+    dropped = 0
+    try:
+        cells_by_sheet = {sheet.name: _cells_by_address(sheet) for sheet in doc.sheets}
+        for ws in styled.worksheets:
+            lookup = cells_by_sheet.get(ws.title, {})
+            recorded_formulas: set[tuple[int, int]] = set()
+            for (row, col), tcell in lookup.items():
+                excel_cell = ws.cell(row=row, column=col)
+                if tcell.kind == "formula" or _excel_cell_is_formula(excel_cell):
+                    dropped += 1
+                    recorded_formulas.add((row, col))
+                if _xlsx_cell_replaced(tcell):
+                    excel_cell.value = tcell.search_text
+                elif tcell.kind == "formula":
+                    excel_cell.value = tcell.original
+            max_row = ws.max_row or 0
+            max_column = ws.max_column or 0
+            if max_row and max_column:
+                for row_cells in ws.iter_rows(
+                    min_row=1, max_row=max_row, max_col=max_column
+                ):
+                    for excel_cell in row_cells:
+                        addr = (excel_cell.row, excel_cell.column)
+                        if addr in recorded_formulas:
+                            continue
+                        if _excel_cell_is_formula(excel_cell):
+                            dropped += 1
+                            excel_cell.value = None
+        styled.save(path)
+    finally:
+        styled.close()
+
+    if dropped:
+        logging.info("Dropped %s formula(s); wrote cached values.", dropped)
+
+
 def save_table(doc: TableDocument, path: str) -> None:
     suffix = Path(path).suffix.lower()
     if suffix == ".xlsx" or doc.kind == "xlsx":
-        _require_openpyxl()
-        raise ValueError(EXCEL_EXTRA_MESSAGE)
+        save_xlsx(doc, path)
+        return
     save_csv(doc, path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pdf-anonymizer-cli = { workspace = true }
 
 [project]
 name = "pdf-anonymizer-workspace"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = []
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
   "ruff",
   "pytest",
   "pytest-mock",
-  "pdf-anonymizer-core[huggingface,google,ollama,openrouter,openai,anthropic]",
+  "pdf-anonymizer-core[huggingface,google,ollama,openrouter,openai,anthropic,excel]",
   "pdf-anonymizer-cli",
   "mkdocs>=1.5.0",
   "mkdocs-material>=9.5.0",

--- a/tests/test_tables_xlsx.py
+++ b/tests/test_tables_xlsx.py
@@ -1,0 +1,329 @@
+"""Excel .xlsx input: load/save, types, formulas, hidden sheets."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook, load_workbook
+
+from pdf_anonymizer_core.core import anonymize_file, anonymize_tabular_file
+from pdf_anonymizer_core.tables import (
+    EXCEL_EXTRA_MESSAGE,
+    apply_mapping_to_table,
+    load_review_text,
+    load_table,
+    save_table,
+)
+from pdf_anonymizer_core.utils import save_results
+
+
+def _build_roster(path: Path) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Employees"
+    ws["A1"] = "Name"
+    ws["B1"] = "Email"
+    ws["C1"] = "Hired"
+    ws["D1"] = "EmployeeId"
+    ws["E1"] = "Active"
+    ws["F1"] = "Notes"
+    ws["G1"] = "Ref"
+    ws["A2"] = "Jane Doe"
+    ws["B2"] = "jane@acme.com"
+    ws["C2"] = datetime(2020, 1, 15)
+    ws["C2"].number_format = "YYYY-MM-DD"
+    ws["D2"] = 123456789
+    ws["D2"].number_format = "000-00-0000"
+    ws["E2"] = True
+    ws["F2"] = "Called John Smith about the Austin office."
+    ws["G2"] = "=A2"
+    ws.column_dimensions["A"].width = 24
+    ws.merge_cells("A3:B3")
+    ws["A3"] = "Merged block"
+
+    hidden = wb.create_sheet("Secrets")
+    hidden.sheet_state = "hidden"
+    hidden["A1"] = "Email"
+    hidden["A2"] = "hidden@acme.com"
+
+    wb.save(path)
+    wb.close()
+    return path
+
+
+def _cells(path: Path, sheet: str) -> dict[tuple[int, int], object]:
+    wb = load_workbook(path, data_only=False)
+    try:
+        ws = wb[sheet]
+        return {
+            (cell.row, cell.column): cell
+            for row in ws.iter_rows()
+            for cell in row
+            if cell.value is not None and cell.value != ""
+        }
+    finally:
+        wb.close()
+
+
+def _any_formula(path: Path) -> bool:
+    wb = load_workbook(path, data_only=False)
+    try:
+        for ws in wb.worksheets:
+            for row in ws.iter_rows():
+                for cell in row:
+                    if cell.data_type == "f":
+                        return True
+                    value = cell.value
+                    if isinstance(value, str) and value.startswith("="):
+                        return True
+                    if type(value).__name__ in {"ArrayFormula", "DataTableFormula"}:
+                        return True
+        return False
+    finally:
+        wb.close()
+
+
+def _anonymize_xlsx(path: Path, **kwargs):
+    defaults = dict(
+        characters_to_anonymize=1000,
+        prompt_template="unused",
+        model_name="unused",
+        use_llm=False,
+    )
+    defaults.update(kwargs)
+    return anonymize_tabular_file(str(path), **defaults)
+
+
+class TestXlsxLoad:
+    def test_multi_sheet_includes_hidden(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        assert doc.kind == "xlsx"
+        assert [sheet.name for sheet in doc.sheets] == ["Employees", "Secrets"]
+        assert doc.sheets[0].hidden is False
+        assert doc.sheets[1].hidden is True
+        lookup = {
+            (cell.sheet, cell.row, cell.column): cell
+            for sheet in doc.sheets
+            for cell in sheet.cells
+        }
+        assert lookup[("Employees", 2, 2)].kind == "text"
+        assert lookup[("Employees", 2, 2)].search_text == "jane@acme.com"
+        assert lookup[("Secrets", 2, 1)].search_text == "hidden@acme.com"
+        emp_id = lookup[("Employees", 2, 4)]
+        assert emp_id.kind == "number"
+        assert emp_id.search_text == "123456789"
+        assert emp_id.original == 123456789
+        hired = lookup[("Employees", 2, 3)]
+        assert hired.kind == "date"
+        assert hired.search_text == "2020-01-15"
+        active = lookup[("Employees", 2, 5)]
+        assert active.kind == "bool"
+        assert active.search_text == ""
+        formula = lookup[("Employees", 2, 7)]
+        assert formula.kind == "formula"
+        assert formula.formula == "=A2"
+
+    def test_display_format_is_not_search_text(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        emp_id = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.row == 2 and cell.column == 4
+        )
+        assert emp_id.search_text == "123456789"
+        assert "123-45-6789" not in emp_id.search_text
+        assert emp_id.number_format == "000-00-0000"
+
+    def test_missing_formula_cache_is_empty(self, tmp_path, caplog) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        with caplog.at_level("WARNING"):
+            doc = load_table(str(src))
+        formula = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.kind == "formula"
+        )
+        assert formula.search_text == ""
+        assert formula.original is None
+        assert "cached value" in caplog.text
+
+
+class TestXlsxAnonymize:
+    def test_multi_sheet_masks_and_preserves_structure(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        assert "jane@acme.com" not in review
+        assert "hidden@acme.com" not in review
+        assert "EMAIL_1" in review
+        assert "# Sheet: Employees" in review
+        assert "# Sheet: Secrets" in review
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        assert out.is_file()
+        wb = load_workbook(out)
+        try:
+            assert wb.sheetnames == ["Employees", "Secrets"]
+            assert wb["Secrets"].sheet_state == "hidden"
+            assert wb["Employees"].column_dimensions["A"].width == 24
+            assert "A3:B3" in wb["Employees"].merged_cells
+            assert wb["Employees"]["B2"].value.startswith("EMAIL_")
+            assert wb["Secrets"]["A2"].value.startswith("EMAIL_")
+        finally:
+            wb.close()
+
+    def test_untouched_types_stay_native_replaced_are_str(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        employees = _cells(out, "Employees")
+        email = employees[(2, 2)]
+        assert isinstance(email.value, str)
+        assert email.value.startswith("EMAIL_")
+        emp_id = employees[(2, 4)]
+        assert emp_id.value == 123456789
+        assert isinstance(emp_id.value, int)
+        active = employees[(2, 5)]
+        assert active.value is True
+        hired = employees[(2, 3)]
+        assert isinstance(hired.value, datetime)
+        assert hired.value == datetime(2020, 1, 15)
+
+    def test_numeric_id_skips_regex_without_llm(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        assert 123456789 not in mapping
+        assert "123456789" not in mapping
+        assert "US_PASSPORT_1" not in review
+        assert "DRIVERS_LICENSE_US_1" not in review
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        emp_id = _cells(Path("data/anonymized/roster.anonymized.xlsx"), "Employees")[
+            (2, 4)
+        ]
+        assert emp_id.value == 123456789
+
+    def test_formulas_never_emitted(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping, entity_texts = _anonymize_xlsx(src)
+        save_results(
+            review,
+            {written: original for original, written in mapping.items()},
+            str(src),
+            entity_texts=entity_texts,
+        )
+        out = Path("data/anonymized/roster.anonymized.xlsx")
+        assert _any_formula(out) is False
+        ref = load_workbook(out)["Employees"]["G2"].value
+        assert ref is None or (not isinstance(ref, str) or not ref.startswith("="))
+
+    def test_replaced_formula_writes_cached_string(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        doc = load_table(str(src))
+        formula = next(
+            cell
+            for cell in doc.sheets[0].cells
+            if cell.row == 2 and cell.column == 7
+        )
+        formula.original = "Jane Doe"
+        formula.search_text = "Jane Doe"
+        apply_mapping_to_table(doc, {"Jane Doe": "PERSON_1"}, ["Jane Doe"])
+        dest = tmp_path / "out.xlsx"
+        save_table(doc, str(dest))
+        assert _any_formula(dest) is False
+        assert load_workbook(dest)["Employees"]["G2"].value == "PERSON_1"
+        assert load_workbook(dest)["Employees"]["A2"].value == "PERSON_1"
+
+    def test_notes_free_text_is_replaced(self, tmp_path, mocker) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        mocker.patch(
+            "pdf_anonymizer_core.core.identify_entities_with_llm",
+            return_value=[
+                {
+                    "text": "John Smith",
+                    "type": "PERSON",
+                    "base_form": "John Smith",
+                },
+                {"text": "Austin", "type": "LOCATION", "base_form": "Austin"},
+            ],
+        )
+        review, mapping, entity_texts = _anonymize_xlsx(src, use_llm=True)
+        assert "John Smith" not in review
+        assert "Austin" not in review
+        assert mapping["John Smith"].startswith("PERSON_")
+        assert mapping["Austin"].startswith("LOCATION_")
+        assert "Called" in review
+        assert "office." in review
+        dest = tmp_path / "notes.xlsx"
+        doc = load_table(str(src))
+        apply_mapping_to_table(doc, mapping, entity_texts)
+        save_table(doc, str(dest))
+        notes = load_workbook(dest)["Employees"]["F2"].value
+        assert "John Smith" not in notes
+        assert "Austin" not in notes
+        assert "Called" in notes
+
+
+class TestXlsxDispatchAndReview:
+    def test_anonymize_file_dispatches_xlsx(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        review, mapping = anonymize_file(
+            str(src), 1000, "unused", "unused", use_llm=False
+        )
+        assert review is not None
+        assert "# Sheet: Employees" in review
+        assert mapping is not None
+        assert "jane@acme.com" in mapping
+
+    def test_load_review_text_flattens_xlsx(self, tmp_path) -> None:
+        src = _build_roster(tmp_path / "roster.xlsx")
+        text = load_review_text(str(src))
+        assert "# Sheet: Employees" in text
+        assert "# Sheet: Secrets" in text
+        assert "jane@acme.com" in text
+        assert " | " in text
+
+    def test_missing_openpyxl_raises_value_error(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        path = tmp_path / "roster.xlsx"
+        path.write_bytes(b"pk")
+        monkeypatch.setitem(sys.modules, "openpyxl", None)
+        with pytest.raises(ValueError, match=r'pdf-anonymizer-core\[excel\]'):
+            load_table(str(path))
+        assert EXCEL_EXTRA_MESSAGE == (
+            "Excel support requires the extra: "
+            'pip install "pdf-anonymizer-core[excel]"'
+        )

--- a/tests/test_tables_xlsx.py
+++ b/tests/test_tables_xlsx.py
@@ -79,10 +79,7 @@ def _any_formula(path: Path) -> bool:
                 for cell in row:
                     if cell.data_type == "f":
                         return True
-                    value = cell.value
-                    if isinstance(value, str) and value.startswith("="):
-                        return True
-                    if type(value).__name__ in {"ArrayFormula", "DataTableFormula"}:
+                    if type(cell.value).__name__ in {"ArrayFormula", "DataTableFormula"}:
                         return True
         return False
     finally:
@@ -265,6 +262,27 @@ class TestXlsxAnonymize:
         assert _any_formula(dest) is False
         assert load_workbook(dest)["Employees"]["G2"].value == "PERSON_1"
         assert load_workbook(dest)["Employees"]["A2"].value == "PERSON_1"
+
+    def test_cached_equals_string_is_not_written_as_formula(self, tmp_path) -> None:
+        src = tmp_path / "eq.xlsx"
+        wb = Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "=A1"
+        wb.save(src)
+        wb.close()
+        doc = load_table(str(src))
+        formula = next(
+            cell for cell in doc.sheets[0].cells if cell.row == 1 and cell.column == 2
+        )
+        formula.original = "=A1"
+        formula.search_text = "=A1"
+        dest = tmp_path / "out.xlsx"
+        save_table(doc, str(dest))
+        assert _any_formula(dest) is False
+        written = load_workbook(dest).active["B1"]
+        assert written.data_type != "f"
+        assert written.value == "=A1"
 
     def test_notes_free_text_is_replaced(self, tmp_path, mocker) -> None:
         src = _build_roster(tmp_path / "roster.xlsx")

--- a/uv.lock
+++ b/uv.lock
@@ -1166,7 +1166,7 @@ wheels = [
 
 [[package]]
 name = "pdf-anonymizer-cli"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "packages/pdf-anonymizer-cli" }
 dependencies = [
     { name = "pdf-anonymizer-core" },
@@ -1190,7 +1190,7 @@ provides-extras = ["excel"]
 
 [[package]]
 name = "pdf-anonymizer-core"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "packages/pdf-anonymizer-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1244,7 +1244,7 @@ provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "a
 
 [[package]]
 name = "pdf-anonymizer-workspace"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -363,6 +363,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1040,6 +1049,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1153,12 +1174,19 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+excel = [
+    { name = "pdf-anonymizer-core", extra = ["excel"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "pdf-anonymizer-core", editable = "packages/pdf-anonymizer-core" },
+    { name = "pdf-anonymizer-core", extras = ["excel"], marker = "extra == 'excel'", editable = "packages/pdf-anonymizer-core" },
     { name = "rich" },
     { name = "typer" },
 ]
+provides-extras = ["excel"]
 
 [[package]]
 name = "pdf-anonymizer-core"
@@ -1176,6 +1204,9 @@ dependencies = [
 [package.optional-dependencies]
 anthropic = [
     { name = "anthropic" },
+]
+excel = [
+    { name = "openpyxl" },
 ]
 google = [
     { name = "google-genai" },
@@ -1205,10 +1236,11 @@ requires-dist = [
     { name = "ollama", marker = "extra == 'ollama'" },
     { name = "openai", marker = "extra == 'openai'" },
     { name = "openai", marker = "extra == 'openrouter'" },
+    { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "pymupdf4llm" },
     { name = "python-dotenv" },
 ]
-provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "anthropic"]
+provides-extras = ["google", "ollama", "huggingface", "openrouter", "openai", "anthropic", "excel"]
 
 [[package]]
 name = "pdf-anonymizer-workspace"
@@ -1228,7 +1260,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pdf-anonymizer-cli" },
-    { name = "pdf-anonymizer-core", extra = ["anthropic", "google", "huggingface", "ollama", "openai", "openrouter"] },
+    { name = "pdf-anonymizer-core", extra = ["anthropic", "excel", "google", "huggingface", "ollama", "openai", "openrouter"] },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -1248,7 +1280,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
     { name = "pdf-anonymizer-cli", editable = "packages/pdf-anonymizer-cli" },
-    { name = "pdf-anonymizer-core", extras = ["huggingface", "google", "ollama", "openrouter", "openai", "anthropic"], editable = "packages/pdf-anonymizer-core" },
+    { name = "pdf-anonymizer-core", extras = ["huggingface", "google", "ollama", "openrouter", "openai", "anthropic", "excel"], editable = "packages/pdf-anonymizer-core" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },


### PR DESCRIPTION
## Summary
User-facing docs and version bump for table input. **0.16.0 → 0.17.0** in all three `pyproject.toml` files.

Depends on #56 and the Excel PR.

`docs/101/*` is unchanged. No k-anonymity or compliance claims.

## Stack
1. CSV — #56
2. Excel
3. **This PR** — docs + 0.17.0

## What changed
- Recipe: anonymize a CSV or Excel roster
- CLI usage, architecture (table path), installation `[excel]`, troubleshooting
- Improvement-plan **item 18** added, left unchecked
- READMEs: Multi-Format includes CSV and Excel

## Test plan
- [ ] Docs preview / `mkdocs build --strict` in CI
- [ ] Confirm 101 pages have no diff